### PR TITLE
add per-candidate industry/lobby breakdown (AI, Oil, Pro-Israel, etc.)

### DIFF
--- a/CODE/src/components/candidates/LobbyBreakdown.tsx
+++ b/CODE/src/components/candidates/LobbyBreakdown.tsx
@@ -1,0 +1,208 @@
+/**
+ * LobbyBreakdown — shows how much money a candidate has accepted from
+ * curated industry / lobby buckets (AI, Oil & Gas, Pro-Israel, Pharma,
+ * Defense, Crypto, Labor) based on FEC Schedule A filings.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, AlertCircle, Building2, ChevronDown, ChevronUp, Info } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import { getCandidateLobbyBreakdown } from "@/lib/api";
+import type { LobbyBreakdownResponse, LobbyBucket } from "@/types/candidate";
+
+function formatCurrency(amount: number): string {
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(1)}K`;
+  return `$${amount.toFixed(0)}`;
+}
+
+interface LobbyRowProps {
+  bucket: LobbyBucket;
+  maxAmount: number;
+}
+
+function LobbyRow({ bucket, maxAmount }: LobbyRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMoney = bucket.totalAmount > 0;
+  const barPct = maxAmount > 0 ? (bucket.totalAmount / maxAmount) * 100 : 0;
+
+  return (
+    <div
+      className={`rounded-lg border bg-card transition-colors ${
+        hasMoney ? "border-border" : "border-border/50 opacity-60"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => hasMoney && setExpanded((v) => !v)}
+        disabled={!hasMoney}
+        className="w-full text-left p-4 flex items-start gap-4"
+      >
+        <span
+          className="mt-1 h-3 w-3 rounded-full shrink-0"
+          style={{ backgroundColor: bucket.color }}
+          aria-hidden
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3 mb-1">
+            <h4 className="font-semibold text-foreground truncate">{bucket.name}</h4>
+            <div className="text-right shrink-0">
+              <p className="font-semibold text-foreground">{formatCurrency(bucket.totalAmount)}</p>
+              <p className="text-xs text-muted-foreground">
+                {bucket.contributionCount} contribution{bucket.contributionCount === 1 ? "" : "s"}
+                {bucket.percentageOfReceipts > 0 && (
+                  <> · {bucket.percentageOfReceipts}% of total</>
+                )}
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mb-2 line-clamp-2">{bucket.description}</p>
+          <Progress value={barPct} className="h-2" />
+        </div>
+        {hasMoney && (
+          <span className="mt-1 shrink-0 text-muted-foreground">
+            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </span>
+        )}
+      </button>
+
+      {expanded && bucket.topContributors.length > 0 && (
+        <div className="border-t border-border px-4 py-3 space-y-2">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Top contributors in this lobby
+          </p>
+          {bucket.topContributors.map((c, idx) => (
+            <div
+              key={`${c.name}-${idx}`}
+              className="flex items-start justify-between gap-3 text-sm"
+            >
+              <div className="min-w-0">
+                <p className="font-medium text-foreground truncate">{c.name}</p>
+                {c.employer && (
+                  <p className="text-xs text-muted-foreground truncate">{c.employer}</p>
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <p className="font-medium text-foreground">{formatCurrency(c.amount)}</p>
+                <p className="text-xs text-muted-foreground">
+                  {c.count} gift{c.count === 1 ? "" : "s"}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface LobbyBreakdownProps {
+  candidateId: string;
+  cycle?: number;
+}
+
+export function LobbyBreakdown({ candidateId, cycle = 2026 }: LobbyBreakdownProps) {
+  const [data, setData] = useState<LobbyBreakdownResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getCandidateLobbyBreakdown(candidateId, cycle)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidateId, cycle]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <p>Aggregating lobby contributions…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium text-foreground">Couldn't load lobby breakdown</p>
+            <p className="text-sm text-muted-foreground">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const maxAmount = data.lobbies.reduce((m, l) => Math.max(m, l.totalAmount), 0);
+  const anyMoney = maxAmount > 0;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h2 className="font-heading text-xl font-semibold text-foreground flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-primary" />
+            Industry & Lobby Breakdown
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            How much this candidate has received from major industry lobbies, classified from
+            itemized FEC filings for the {data.cycle} cycle.
+          </p>
+        </div>
+        {anyMoney && (
+          <div className="text-right shrink-0">
+            <p className="text-xs text-muted-foreground">Classified</p>
+            <p className="font-semibold text-foreground">
+              {formatCurrency(data.totalLobbyAmount)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {data.classifiedPercentage}% of receipts
+            </p>
+          </div>
+        )}
+      </div>
+
+      {anyMoney ? (
+        <div className="space-y-3">
+          {data.lobbies.map((bucket) => (
+            <LobbyRow key={bucket.id} bucket={bucket} maxAmount={maxAmount} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          No contributions matching tracked lobbies were found for this candidate yet.
+        </div>
+      )}
+
+      <div className="mt-4 flex items-start gap-2 text-xs text-muted-foreground">
+        <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          {data.notes.map((note, i) => (
+            <p key={i}>{note}</p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/CODE/src/components/candidates/index.ts
+++ b/CODE/src/components/candidates/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { CandidateCard } from './CandidateCard';
+export { LobbyBreakdown } from './LobbyBreakdown';

--- a/CODE/src/lib/api.ts
+++ b/CODE/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ApiError,
   CandidateFinanceResponse,
   DetailedFinanceResponse,
+  LobbyBreakdownResponse,
   Election,
   ElectionsResponse,
   GetElectionsParams,
@@ -210,6 +211,23 @@ export async function getCandidateDetailedFinances(
 
   const endpoint = `/candidates/${id}/finances/detailed?cycle=${cycle}`;
   return fetchAPI<DetailedFinanceResponse>(endpoint);
+}
+
+/**
+ * Get industry/lobby breakdown of donations for a candidate.
+ * Aggregates itemized FEC receipts into curated lobby buckets
+ * (AI / Big Tech, Oil & Gas, Pro-Israel, Pharma, Defense, Crypto, Labor).
+ */
+export async function getCandidateLobbyBreakdown(
+  id: string,
+  cycle: number = 2026
+): Promise<LobbyBreakdownResponse> {
+  if (!id || id.trim() === '') {
+    throw new Error('Candidate ID is required');
+  }
+
+  const endpoint = `/candidates/${id}/lobby-breakdown?cycle=${cycle}`;
+  return fetchAPI<LobbyBreakdownResponse>(endpoint);
 }
 
 /**

--- a/CODE/src/pages/Candidates.tsx
+++ b/CODE/src/pages/Candidates.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { getCandidateById, getCandidateDetailedFinances } from "@/lib/api";
 import type { Candidate, DetailedFinanceResponse } from "@/types/candidate";
+import { LobbyBreakdown } from "@/components/candidates/LobbyBreakdown";
 
 /**
  * Format currency amount to readable string
@@ -586,6 +587,9 @@ export default function Candidates() {
                       </div>
                     </div>
                   )}
+
+                  {/* Industry / Lobby Breakdown */}
+                  {id && <LobbyBreakdown candidateId={id} cycle={2026} />}
 
                   {/* Spending Categories */}
                   {spendingCategories.length > 0 && (

--- a/CODE/src/types/candidate.ts
+++ b/CODE/src/types/candidate.ts
@@ -221,6 +221,45 @@ export interface DetailedFinanceResponse {
 }
 
 /**
+ * Top contributor inside a lobby bucket
+ */
+export interface LobbyContributor {
+  name: string;
+  employer: string | null;
+  amount: number;
+  count: number;
+}
+
+/**
+ * One industry/lobby bucket in the candidate's lobby breakdown
+ */
+export interface LobbyBucket {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  totalAmount: number;
+  contributionCount: number;
+  percentageOfReceipts: number;
+  topContributors: LobbyContributor[];
+}
+
+/**
+ * Full lobby/industry breakdown response for a candidate
+ */
+export interface LobbyBreakdownResponse {
+  candidateId: string;
+  candidateName: string;
+  cycle: number;
+  totalReceipts: number;
+  totalLobbyAmount: number;
+  classifiedPercentage: number;
+  lobbies: LobbyBucket[];
+  lastComputed: string;
+  notes: string[];
+}
+
+/**
  * Election information
  */
 export interface Election {

--- a/PHASE5_PLAN.md
+++ b/PHASE5_PLAN.md
@@ -1,0 +1,100 @@
+# Phase 5 — Donor & Lobby Breakdown per Candidate
+
+Goal: every candidate page should let a voter see, at a glance, **how much
+money the candidate has accepted from major industry lobbies** (AI, Oil &
+Gas, Pro-Israel, Pharma, Defense, Crypto, Labor) — in addition to the
+existing top-donor list.
+
+All work happens directly on the `phase5` branch.
+
+## What ships in this phase
+
+### Backend (`/backend`)
+
+1. **Lobby taxonomy** — `src/data/lobbies.ts`
+   - Hand-curated list of lobby buckets with three matchers each:
+     - `committeeIds` — known FEC committee IDs (kept for future use)
+     - `namePatterns` — case-insensitive regex against `Receipt.contributorName`
+       (catches PAC contributions where the contributor IS the PAC)
+     - `employerPatterns` — case-insensitive regex against
+       `Receipt.contributorEmployer` (catches industry-employed individual donors)
+   - Seeded with: AI / Big Tech, Oil & Gas, Pro-Israel, Pharma & Health
+     Products, Defense & Aerospace, Crypto & Blockchain, Organized Labor.
+
+2. **LobbyService** — `src/services/lobby.service.ts`
+   - `getLobbyCatalog()` — returns the static list (id, name, description, color).
+   - `getLobbyBreakdown(candidateDbId, cycle)` —
+     1. Resolve candidate → committees.
+     2. Pre-filter `Receipt` rows in SQL via a single `OR` of `ILIKE`
+        substrings (one per pattern), scoped to the cycle date window
+        `[cycle-1, cycle]`. This is just a coarse pre-filter so we don't
+        scan tens of thousands of receipts in JS.
+     3. Run real regex matching in JS to bucket each receipt into a lobby.
+     4. Compute per-lobby totals, contribution counts, and top 5
+        contributors per lobby.
+     5. Compute `totalReceipts` (cycle-windowed aggregate) for context
+        and `classifiedPercentage` of receipts that fell into a lobby.
+
+3. **API endpoints** (`src/controllers/candidate.controller.ts`,
+   `src/routes/candidates.routes.ts`, `src/routes/index.ts`)
+   - `GET /api/candidates/:id/lobby-breakdown?cycle=2026` — full breakdown.
+   - `GET /api/lobbies` — static catalog (for legends / future filters).
+
+### Frontend (`/CODE`)
+
+1. **Types & API client**
+   - `src/types/candidate.ts` — adds `LobbyContributor`, `LobbyBucket`,
+     `LobbyBreakdownResponse`.
+   - `src/lib/api.ts` — adds `getCandidateLobbyBreakdown(id, cycle)`.
+
+2. **`LobbyBreakdown` component**
+   - `src/components/candidates/LobbyBreakdown.tsx`
+   - Card with one row per lobby, sorted by total amount.
+   - Each row shows:
+     - Color dot, lobby name, short description
+     - `$total received` and `% of receipts` on the right
+     - A horizontal bar (relative to the largest bucket in the breakdown)
+     - Click-to-expand reveals the **top 5 contributors in that lobby**
+       with their employer + dollar amount + count of gifts
+   - Header summary: `classified $ / % of receipts` for the candidate.
+   - Inline disclaimer notes (under-$200 individual gifts not itemized,
+     employer self-reporting limitations).
+   - Empty / loading / error states all handled.
+
+3. **Wired into the existing candidate profile page**
+   - `src/pages/Candidates.tsx` — inside the existing **Campaign Finance**
+     tab, slotted between *Top Contributors* and *Spending Breakdown*.
+   - Loads lazily (its own `useEffect`) so the rest of the finance tab
+     renders immediately.
+
+## Design notes / tradeoffs
+
+- **Coverage is conservative.** The lobby lists are hand-curated — total
+  numbers will undercount, never overcount. Easy to extend by editing
+  `backend/src/data/lobbies.ts`.
+- **No new database columns / migrations.** The aggregation runs against
+  the existing `Receipt` table and is computed on demand. If this gets
+  slow we can cache results in a `LobbyAggregate` table keyed on
+  `(candidateId, cycle)` and refresh on the existing weekly sync.
+- **No OpenSecrets dependency.** Their bulk industry codes (CRP IDs)
+  would give broader coverage, but require registration and license
+  compliance. We can layer them in later behind the same service shape.
+- **Cycle filter uses `contributionReceiptDate` window** (`[cycle-1, cycle]`)
+  rather than a stored cycle column on the receipt. Existing detailed
+  finances code does not filter by cycle at all — the lobby breakdown
+  is actually stricter on this dimension.
+- **Pro-Israel bucket** is name-pattern only by design (employer-pattern
+  matching for it produces too many false positives — e.g. anyone employed
+  by an Israeli-headquartered tech firm).
+
+## Future extensions (not in this phase)
+
+- Persist a precomputed `LobbyAggregate` table refreshed by the
+  weekly FEC sync job, so the endpoint is O(lobbies) rather than scanning
+  receipts on every request.
+- Add a **filter on the candidates list page** to find candidates with
+  the highest take from a given lobby ("Show me Senate candidates ranked
+  by Oil & Gas dollars").
+- Pull in OpenSecrets CRP industry codes for finer industry coverage.
+- Surface lobby badges on the `CandidateCard` (e.g. "Top recipient of AI
+  lobby money in CA").

--- a/backend/src/controllers/candidate.controller.ts
+++ b/backend/src/controllers/candidate.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { candidateService } from '../services/candidate.service.js';
 import { financeService } from '../services/finance.service.js';
+import { lobbyService } from '../services/lobby.service.js';
 
 export class CandidateController {
   /**
@@ -153,6 +154,43 @@ export class CandidateController {
       }
       
       res.status(500).json({ error: 'Failed to fetch detailed finances', message: error.message });
+    }
+  }
+
+  /**
+   * GET /api/candidates/:id/lobby-breakdown
+   * Aggregate the candidate's itemized receipts into industry / lobby buckets
+   * (AI, Oil & Gas, Pro-Israel, Pharma, Defense, Crypto, Labor).
+   */
+  async getCandidateLobbyBreakdown(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { cycle } = req.query;
+      const cycleNum = cycle ? parseInt(cycle as string) : 2026;
+
+      const breakdown = await lobbyService.getLobbyBreakdown(id, cycleNum);
+      res.json(breakdown);
+    } catch (error: any) {
+      console.error('Error getting lobby breakdown:', error);
+
+      if (error.message === 'Candidate not found') {
+        res.status(404).json({ error: 'Candidate not found' });
+        return;
+      }
+
+      res.status(500).json({ error: 'Failed to compute lobby breakdown', message: error.message });
+    }
+  }
+
+  /**
+   * GET /api/lobbies
+   * Static catalog of supported lobbies (used by UI legends).
+   */
+  async getLobbyCatalog(_req: Request, res: Response): Promise<void> {
+    try {
+      res.json({ lobbies: lobbyService.getLobbyCatalog() });
+    } catch (error: any) {
+      res.status(500).json({ error: 'Failed to fetch lobby catalog', message: error.message });
     }
   }
 

--- a/backend/src/data/lobbies.ts
+++ b/backend/src/data/lobbies.ts
@@ -1,0 +1,338 @@
+/**
+ * Industry / lobby classification for FEC contributions.
+ *
+ * For each lobby we match Receipt rows three ways:
+ *   - committeeIds: exact FEC committee ID of a contributing PAC
+ *   - namePatterns: case-insensitive regex against contributorName
+ *     (catches PAC contributions where the contributor IS the PAC)
+ *   - employerPatterns: case-insensitive regex against contributorEmployer
+ *     (catches individual donors employed by industry firms)
+ *
+ * Sources: FEC.gov public committee filings, OpenSecrets industry
+ * classifications (CRP codes — public reference), major-employer lists.
+ *
+ * Intentionally conservative — totals will undercount but should not
+ * overcount. Update the lists below to expand coverage.
+ */
+export interface LobbyDefinition {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  committeeIds: string[];
+  namePatterns: string[];
+  employerPatterns: string[];
+}
+
+export const LOBBIES: LobbyDefinition[] = [
+  {
+    id: 'ai',
+    name: 'AI / Big Tech',
+    description:
+      'Artificial intelligence companies, model labs, and the largest cloud/compute providers backing AI policy.',
+    color: '#8b5cf6',
+    committeeIds: [
+      'C00428235', // Google Inc. NetPAC
+      'C00487777', // Microsoft Corp PAC
+      'C00428912', // Amazon.com PAC
+      'C00819872', // Fairshake (crypto+tech aligned)
+      'C00770273', // Meta Platforms PAC
+      'C00838526', // Leading the Future (AI policy super PAC)
+    ],
+    namePatterns: [
+      'leading the future',
+      'americans for ai',
+      'fairshake',
+      'google.*pac',
+      'microsoft.*pac',
+      'alphabet inc',
+      'meta platforms.*pac',
+      'amazon\\.com.*pac',
+      'nvidia.*pac',
+      'ibm.*pac',
+      'oracle.*pac',
+      'salesforce.*pac',
+    ],
+    employerPatterns: [
+      'openai',
+      'anthropic',
+      'google',
+      'alphabet',
+      'deepmind',
+      'microsoft',
+      'meta platforms',
+      'facebook',
+      'nvidia',
+      'amazon',
+      'amazon web services',
+      '\\baws\\b',
+      'apple inc',
+      'oracle',
+      '\\bibm\\b',
+      'salesforce',
+      'scale ai',
+      'perplexity',
+      'mistral',
+      'cohere',
+      'databricks',
+      'palantir',
+      'huggingface',
+      'hugging face',
+      'stability ai',
+      '\\bxai\\b',
+      'x\\.ai',
+    ],
+  },
+  {
+    id: 'oil_gas',
+    name: 'Oil & Gas',
+    description:
+      'Oil majors, independents, refiners, pipeline operators, and their trade-association PACs.',
+    color: '#1f2937',
+    committeeIds: [
+      'C00126774', // Chevron Employees PAC
+      'C00012245', // ExxonMobil PAC
+      'C00041681', // ConocoPhillips SPIRIT PAC
+      'C00177439', // Marathon Petroleum Corp Employees PAC
+      'C00033710', // Halliburton Co PAC
+      'C00078451', // Koch Industries PAC (KOCHPAC)
+      'C00114531', // American Petroleum Institute PAC
+      'C00263601', // Independent Petroleum Assn of America PAC
+      'C00107477', // Occidental Petroleum Corp PAC
+      'C00193337', // Valero Energy Corp PAC
+    ],
+    namePatterns: [
+      'exxon.*pac',
+      'chevron.*pac',
+      'conocophillips.*pac',
+      'occidental.*pac',
+      'marathon.*pac',
+      'valero.*pac',
+      'phillips 66.*pac',
+      'halliburton.*pac',
+      'schlumberger.*pac',
+      'koch industries.*pac',
+      'energy transfer.*pac',
+      'kinder morgan.*pac',
+      'enterprise products.*pac',
+      'american petroleum institute',
+      '\\bapi pac\\b',
+      'ipaa pac',
+      'independent petroleum',
+    ],
+    employerPatterns: [
+      'exxon',
+      'exxonmobil',
+      'chevron',
+      'conocophillips',
+      'occidental petroleum',
+      'marathon petroleum',
+      'marathon oil',
+      'valero',
+      'phillips 66',
+      'shell oil',
+      'shell usa',
+      'halliburton',
+      'schlumberger',
+      'baker hughes',
+      'koch industries',
+      'energy transfer',
+      'kinder morgan',
+      'enterprise products',
+      'pioneer natural',
+      'devon energy',
+      'eog resources',
+      'hess corporation',
+      'american petroleum institute',
+    ],
+  },
+  {
+    id: 'pro_israel',
+    name: 'Pro-Israel',
+    description:
+      'PACs and organizations that explicitly advocate U.S.-Israel policy alignment. Includes both bipartisan and partisan-leaning groups.',
+    color: '#0ea5e9',
+    committeeIds: [
+      'C00797670', // United Democracy Project (AIPAC-affiliated super PAC)
+      'C00127811', // AIPAC PAC
+      'C00734301', // Democratic Majority for Israel
+      'C00528081', // Republican Jewish Coalition PAC
+      'C00130377', // NORPAC
+      'C00368856', // Pro-Israel America PAC
+      'C00497915', // To Protect Our Heritage PAC
+      'C00136473', // Joint Action Committee for Political Affairs (JACPAC)
+      'C00098699', // Washington PAC
+      'C00499945', // Hudson Valley PAC
+    ],
+    namePatterns: [
+      '\\baipac\\b',
+      'united democracy project',
+      'democratic majority for israel',
+      'republican jewish coalition',
+      'norpac',
+      'jacpac',
+      'pro-israel america',
+      'to protect our heritage',
+      'joint action committee for political affairs',
+      'florida congressional committee',
+      'hudson valley pac',
+      'desert caucus',
+      'washington pac',
+    ],
+    employerPatterns: [],
+  },
+  {
+    id: 'pharma',
+    name: 'Pharma & Health Products',
+    description: 'Pharmaceutical manufacturers, biotech firms, and PhRMA-affiliated PACs.',
+    color: '#ef4444',
+    committeeIds: [
+      'C00081496', // Pfizer Inc PAC
+      'C00043604', // Merck & Co Inc PAC
+      'C00025260', // Eli Lilly & Co PAC
+      'C00131110', // Johnson & Johnson PAC
+      'C00141788', // AbbVie Inc PAC
+      'C00248818', // Amgen Inc PAC
+      'C00345366', // PhRMA PAC
+    ],
+    namePatterns: [
+      'pfizer.*pac',
+      'merck.*pac',
+      'eli lilly.*pac',
+      'johnson & johnson.*pac',
+      'abbvie.*pac',
+      'bristol.*myers.*pac',
+      'amgen.*pac',
+      'novartis.*pac',
+      'gilead.*pac',
+      'phrma pac',
+      'biotechnology innovation',
+    ],
+    employerPatterns: [
+      'pfizer',
+      'merck',
+      'eli lilly',
+      'johnson & johnson',
+      'abbvie',
+      'bristol-myers',
+      'bristol myers squibb',
+      'amgen',
+      'novartis',
+      'gilead',
+      'regeneron',
+      'moderna',
+      'biontech',
+      'sanofi',
+      'astrazeneca',
+      'glaxosmithkline',
+      '\\bgsk\\b',
+      'phrma',
+    ],
+  },
+  {
+    id: 'defense',
+    name: 'Defense & Aerospace',
+    description: 'Major defense contractors and aerospace manufacturers with federal contracts.',
+    color: '#475569',
+    committeeIds: [
+      'C00277345', // Lockheed Martin Employees PAC
+      'C00010057', // Boeing Co PAC
+      'C00146574', // Raytheon Co PAC (RTX)
+      'C00034298', // Northrop Grumman Corp PAC
+      'C00224946', // General Dynamics Voluntary Political Contribution Plan
+      'C00134290', // L3Harris Technologies PAC
+    ],
+    namePatterns: [
+      'lockheed martin.*pac',
+      'boeing.*pac',
+      'raytheon.*pac',
+      'rtx.*pac',
+      'northrop grumman.*pac',
+      'general dynamics.*pac',
+      'l3harris.*pac',
+      'huntington ingalls.*pac',
+      'leidos.*pac',
+    ],
+    employerPatterns: [
+      'lockheed martin',
+      'boeing',
+      'raytheon',
+      'rtx corp',
+      'northrop grumman',
+      'general dynamics',
+      'l3harris',
+      'huntington ingalls',
+      'leidos',
+      'booz allen',
+      '\\bsaic\\b',
+      'anduril',
+    ],
+  },
+  {
+    id: 'crypto',
+    name: 'Crypto & Blockchain',
+    description: 'Cryptocurrency exchanges, blockchain firms, and major crypto-aligned PACs.',
+    color: '#f59e0b',
+    committeeIds: [
+      'C00819872', // Fairshake
+      'C00835959', // Defend American Jobs
+      'C00836155', // Protect Progress
+      'C00805954', // Crypto Innovation PAC
+    ],
+    namePatterns: [
+      'fairshake',
+      'defend american jobs',
+      'protect progress',
+      'coinbase.*pac',
+      'kraken.*pac',
+      'ripple.*pac',
+    ],
+    employerPatterns: [
+      'coinbase',
+      'kraken',
+      'ripple',
+      'circle internet',
+      'binance',
+      'gemini trust',
+      'andreessen horowitz',
+      '\\ba16z\\b',
+      'polygon labs',
+      'consensys',
+      'uniswap',
+    ],
+  },
+  {
+    id: 'labor',
+    name: 'Organized Labor',
+    description: 'Major labor unions and their political committees.',
+    color: '#10b981',
+    committeeIds: [
+      'C00004036', // AFL-CIO COPE
+      'C00004606', // SEIU COPE
+      'C00010132', // AFSCME PEOPLE
+      'C00026789', // UAW V-CAP
+      'C00036214', // Teamsters DRIVE
+      'C00010561', // NEA Fund for Children & Public Education
+      'C00177436', // American Federation of Teachers (AFT) Committee on Political Education
+      'C00345057', // IBEW PAC
+    ],
+    namePatterns: [
+      'afl-cio',
+      'afl cio',
+      'seiu cope',
+      'afscme pac',
+      'afscme people',
+      '\\buaw\\b',
+      'teamsters drive',
+      'national education association',
+      'nea fund',
+      'american federation of teachers',
+      'aft committee',
+      'carpenters legislative',
+      'ibew pac',
+      'ufcw active ballot',
+      'machinists non-partisan',
+    ],
+    employerPatterns: [],
+  },
+];

--- a/backend/src/routes/candidates.routes.ts
+++ b/backend/src/routes/candidates.routes.ts
@@ -15,6 +15,9 @@ router.get('/:id', (req, res) => candidateController.getCandidateById(req, res))
 // Get detailed candidate finances (funding sources, top donors, spending categories)
 router.get('/:id/finances/detailed', (req, res) => candidateController.getCandidateDetailedFinances(req, res));
 
+// Get lobby/industry breakdown of donations for this candidate
+router.get('/:id/lobby-breakdown', (req, res) => candidateController.getCandidateLobbyBreakdown(req, res));
+
 // Get candidate finances (basic summary)
 router.get('/:id/finances', (req, res) => candidateController.getCandidateFinances(req, res));
 

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import deadlinesRoutes from './deadlines.routes.js';
 import chatRoutes from './chat.routes.js';
 import researcherAuthRoutes from './researcher-auth.routes.js';
 import researchRoutes from './research.routes.js';
+import { candidateController } from '../controllers/candidate.controller.js';
 import { prisma } from '../config/database.js';
 
 const router = Router();
@@ -20,6 +21,9 @@ router.use('/deadlines', deadlinesRoutes);
 router.use('/chat', chatRoutes);
 router.use('/auth/researcher', researcherAuthRoutes);
 router.use('/research', researchRoutes);
+
+// Static catalog of supported lobbies (for UI legends/filters)
+router.get('/lobbies', (req, res) => candidateController.getLobbyCatalog(req, res));
 
 // Health check endpoint
 router.get('/health', async (_req, res) => {

--- a/backend/src/services/lobby.service.ts
+++ b/backend/src/services/lobby.service.ts
@@ -1,0 +1,260 @@
+import { prisma } from '../config/database.js';
+import { LOBBIES, LobbyDefinition } from '../data/lobbies.js';
+
+export interface LobbyContributor {
+  name: string;
+  employer: string | null;
+  amount: number;
+  count: number;
+}
+
+export interface LobbyBucket {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  totalAmount: number;
+  contributionCount: number;
+  percentageOfReceipts: number;
+  topContributors: LobbyContributor[];
+}
+
+export interface LobbyBreakdownResult {
+  candidateId: string;
+  candidateName: string;
+  cycle: number;
+  totalReceipts: number;
+  totalLobbyAmount: number;
+  classifiedPercentage: number;
+  lobbies: LobbyBucket[];
+  lastComputed: string;
+  notes: string[];
+}
+
+/**
+ * Strip regex-only tokens so a pattern can be used as a SQL ILIKE substring.
+ * (Word boundaries / character classes are dropped — final classification
+ * still uses real regex on the in-memory result, this is just a coarse
+ * pre-filter to limit how many rows we pull from the DB.)
+ */
+function patternToSqlSubstring(pattern: string): string {
+  return pattern
+    .replace(/\\b/g, '')
+    .replace(/\.\*/g, ' ')
+    .replace(/\\\./g, '.')
+    .replace(/[\^$()|+?{}[\]]/g, '')
+    .trim();
+}
+
+function compilePattern(pattern: string): RegExp {
+  return new RegExp(pattern, 'i');
+}
+
+interface CompiledLobby extends LobbyDefinition {
+  nameRegexes: RegExp[];
+  employerRegexes: RegExp[];
+  committeeIdSet: Set<string>;
+}
+
+const COMPILED: CompiledLobby[] = LOBBIES.map((l) => ({
+  ...l,
+  nameRegexes: l.namePatterns.map(compilePattern),
+  employerRegexes: l.employerPatterns.map(compilePattern),
+  committeeIdSet: new Set(l.committeeIds),
+}));
+
+function matchLobby(
+  contributorName: string | null,
+  contributorEmployer: string | null,
+): CompiledLobby | null {
+  for (const lobby of COMPILED) {
+    if (contributorName) {
+      for (const re of lobby.nameRegexes) {
+        if (re.test(contributorName)) return lobby;
+      }
+    }
+    if (contributorEmployer) {
+      for (const re of lobby.employerRegexes) {
+        if (re.test(contributorEmployer)) return lobby;
+      }
+    }
+  }
+  return null;
+}
+
+export class LobbyService {
+  /**
+   * Get the static catalog of supported lobbies (for UI legends, filters).
+   */
+  getLobbyCatalog(): { id: string; name: string; description: string; color: string }[] {
+    return LOBBIES.map((l) => ({
+      id: l.id,
+      name: l.name,
+      description: l.description,
+      color: l.color,
+    }));
+  }
+
+  /**
+   * Aggregate a candidate's receipts into lobby buckets.
+   *
+   * Strategy:
+   *   1. Find the candidate's committees.
+   *   2. Pre-filter receipts in SQL via a giant OR of ILIKE substrings
+   *      (so we don't scan tens of thousands of rows in JS).
+   *   3. Classify each candidate receipt in JS using the compiled regexes,
+   *      bucket by lobby, and track top contributors.
+   *   4. Compute percentage of *total* receipts for context.
+   */
+  async getLobbyBreakdown(
+    candidateDbId: string,
+    cycle: number = 2026,
+  ): Promise<LobbyBreakdownResult> {
+    const candidate = await prisma.candidate.findUnique({
+      where: { id: candidateDbId },
+      include: { committees: true },
+    });
+
+    if (!candidate) {
+      throw new Error('Candidate not found');
+    }
+
+    const committeeIds = candidate.committees.map((c) => c.committeeId);
+    const buckets = new Map<string, LobbyBucket>();
+    const contributorByLobby = new Map<string, Map<string, LobbyContributor>>();
+
+    for (const lobby of COMPILED) {
+      buckets.set(lobby.id, {
+        id: lobby.id,
+        name: lobby.name,
+        description: lobby.description,
+        color: lobby.color,
+        totalAmount: 0,
+        contributionCount: 0,
+        percentageOfReceipts: 0,
+        topContributors: [],
+      });
+      contributorByLobby.set(lobby.id, new Map());
+    }
+
+    if (committeeIds.length === 0) {
+      return {
+        candidateId: candidate.candidateId,
+        candidateName: candidate.name,
+        cycle,
+        totalReceipts: 0,
+        totalLobbyAmount: 0,
+        classifiedPercentage: 0,
+        lobbies: Array.from(buckets.values()),
+        lastComputed: new Date().toISOString(),
+        notes: ['No committees on file for this candidate.'],
+      };
+    }
+
+    // Build the OR pre-filter from every name/employer pattern across all lobbies.
+    const orFilters: object[] = [];
+    for (const lobby of LOBBIES) {
+      for (const pattern of lobby.namePatterns) {
+        const term = patternToSqlSubstring(pattern);
+        if (term.length >= 2) {
+          orFilters.push({ contributorName: { contains: term, mode: 'insensitive' } });
+        }
+      }
+      for (const pattern of lobby.employerPatterns) {
+        const term = patternToSqlSubstring(pattern);
+        if (term.length >= 2) {
+          orFilters.push({ contributorEmployer: { contains: term, mode: 'insensitive' } });
+        }
+      }
+    }
+
+    // Cycle window: a 2-year cycle covers donations from Jan of the prior odd
+    // year through Dec of the cycle year (e.g. cycle=2026 → 2025-01-01..2026-12-31).
+    const cycleStart = new Date(`${cycle - 1}-01-01T00:00:00Z`);
+    const cycleEnd = new Date(`${cycle}-12-31T23:59:59Z`);
+
+    const [candidateReceipts, totalAgg] = await Promise.all([
+      prisma.receipt.findMany({
+        where: {
+          committeeId: { in: committeeIds },
+          contributionReceiptDate: { gte: cycleStart, lte: cycleEnd },
+          OR: orFilters,
+        },
+        select: {
+          contributorName: true,
+          contributorEmployer: true,
+          contributionReceiptAmount: true,
+        },
+      }),
+      prisma.receipt.aggregate({
+        where: {
+          committeeId: { in: committeeIds },
+          contributionReceiptDate: { gte: cycleStart, lte: cycleEnd },
+        },
+        _sum: { contributionReceiptAmount: true },
+      }),
+    ]);
+
+    let totalLobbyAmount = 0;
+
+    for (const r of candidateReceipts) {
+      const lobby = matchLobby(r.contributorName, r.contributorEmployer);
+      if (!lobby) continue;
+
+      const amount = r.contributionReceiptAmount?.toNumber() ?? 0;
+      if (amount <= 0) continue;
+
+      const bucket = buckets.get(lobby.id)!;
+      bucket.totalAmount += amount;
+      bucket.contributionCount += 1;
+      totalLobbyAmount += amount;
+
+      const key = (r.contributorName ?? 'Unknown').trim().toUpperCase();
+      const contribMap = contributorByLobby.get(lobby.id)!;
+      const existing = contribMap.get(key);
+      if (existing) {
+        existing.amount += amount;
+        existing.count += 1;
+      } else {
+        contribMap.set(key, {
+          name: r.contributorName ?? 'Unknown',
+          employer: r.contributorEmployer,
+          amount,
+          count: 1,
+        });
+      }
+    }
+
+    const totalReceipts = totalAgg._sum.contributionReceiptAmount?.toNumber() ?? 0;
+
+    for (const bucket of buckets.values()) {
+      const top = Array.from(contributorByLobby.get(bucket.id)!.values())
+        .sort((a, b) => b.amount - a.amount)
+        .slice(0, 5);
+      bucket.topContributors = top;
+      bucket.percentageOfReceipts =
+        totalReceipts > 0 ? Math.round((bucket.totalAmount / totalReceipts) * 1000) / 10 : 0;
+    }
+
+    const lobbies = Array.from(buckets.values()).sort((a, b) => b.totalAmount - a.totalAmount);
+
+    return {
+      candidateId: candidate.candidateId,
+      candidateName: candidate.name,
+      cycle,
+      totalReceipts,
+      totalLobbyAmount,
+      classifiedPercentage:
+        totalReceipts > 0 ? Math.round((totalLobbyAmount / totalReceipts) * 1000) / 10 : 0,
+      lobbies,
+      lastComputed: new Date().toISOString(),
+      notes: [
+        'Classification uses keyword matching against contributor name and employer fields from FEC Schedule A filings.',
+        'Itemized individual contributions only exist for donations over $200; smaller donations are not classified here.',
+        'Self-reported employer fields ("Self", "Retired", etc.) cause undercounting — totals are a lower bound.',
+      ],
+    };
+  }
+}
+
+export const lobbyService = new LobbyService();


### PR DESCRIPTION
Voters can now click into any candidate and see how much money they have accepted from major industry lobbies, in addition to the existing top-donor list.

Backend:
- src/data/lobbies.ts: hand-curated taxonomy (committee IDs, contributor name patterns, employer patterns) for 7 lobby buckets.
- src/services/lobby.service.ts: aggregates Receipt rows for a candidate into lobby buckets, with cycle-windowed totals, top contributors per lobby, and percentage-of-receipts context.
- GET /api/candidates/:id/lobby-breakdown and GET /api/lobbies endpoints.

Frontend:
- LobbyBreakdown component with sorted bars, expandable top contributors per lobby, and inline disclaimers about FEC itemization limits.
- Wired into the existing Campaign Finance tab on the candidate profile.

PHASE5_PLAN.md documents the design, tradeoffs, and future extensions (precomputed aggregates, OpenSecrets CRP integration, candidate-list filtering).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lobby and Industry Breakdown: New candidate-profile section showing contributions by industry/lobby with totals, percentages, per-category progress bars, expandable top-contributor lists, and clear loading/error/empty states.
* **Documentation**
  * Added Phase 5 plan describing donor & lobby breakdown goals and rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->