### PR TITLE
add per-candidate industry/lobby breakdown (AI, Oil, Pro-Israel, etc.)

### DIFF
--- a/CODE/src/components/candidates/LobbyBreakdown.tsx
+++ b/CODE/src/components/candidates/LobbyBreakdown.tsx
@@ -1,0 +1,208 @@
+/**
+ * LobbyBreakdown — shows how much money a candidate has accepted from
+ * curated industry / lobby buckets (AI, Oil & Gas, Pro-Israel, Pharma,
+ * Defense, Crypto, Labor) based on FEC Schedule A filings.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, AlertCircle, Building2, ChevronDown, ChevronUp, Info } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import { getCandidateLobbyBreakdown } from "@/lib/api";
+import type { LobbyBreakdownResponse, LobbyBucket } from "@/types/candidate";
+
+function formatCurrency(amount: number): string {
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(1)}K`;
+  return `$${amount.toFixed(0)}`;
+}
+
+interface LobbyRowProps {
+  bucket: LobbyBucket;
+  maxAmount: number;
+}
+
+function LobbyRow({ bucket, maxAmount }: LobbyRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMoney = bucket.totalAmount > 0;
+  const barPct = maxAmount > 0 ? (bucket.totalAmount / maxAmount) * 100 : 0;
+
+  return (
+    <div
+      className={`rounded-lg border bg-card transition-colors ${
+        hasMoney ? "border-border" : "border-border/50 opacity-60"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => hasMoney && setExpanded((v) => !v)}
+        disabled={!hasMoney}
+        className="w-full text-left p-4 flex items-start gap-4"
+      >
+        <span
+          className="mt-1 h-3 w-3 rounded-full shrink-0"
+          style={{ backgroundColor: bucket.color }}
+          aria-hidden
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3 mb-1">
+            <h4 className="font-semibold text-foreground truncate">{bucket.name}</h4>
+            <div className="text-right shrink-0">
+              <p className="font-semibold text-foreground">{formatCurrency(bucket.totalAmount)}</p>
+              <p className="text-xs text-muted-foreground">
+                {bucket.contributionCount} contribution{bucket.contributionCount === 1 ? "" : "s"}
+                {bucket.percentageOfReceipts > 0 && (
+                  <> · {bucket.percentageOfReceipts}% of total</>
+                )}
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mb-2 line-clamp-2">{bucket.description}</p>
+          <Progress value={barPct} className="h-2" />
+        </div>
+        {hasMoney && (
+          <span className="mt-1 shrink-0 text-muted-foreground">
+            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </span>
+        )}
+      </button>
+
+      {expanded && bucket.topContributors.length > 0 && (
+        <div className="border-t border-border px-4 py-3 space-y-2">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Top contributors in this lobby
+          </p>
+          {bucket.topContributors.map((c, idx) => (
+            <div
+              key={`${c.name}-${idx}`}
+              className="flex items-start justify-between gap-3 text-sm"
+            >
+              <div className="min-w-0">
+                <p className="font-medium text-foreground truncate">{c.name}</p>
+                {c.employer && (
+                  <p className="text-xs text-muted-foreground truncate">{c.employer}</p>
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <p className="font-medium text-foreground">{formatCurrency(c.amount)}</p>
+                <p className="text-xs text-muted-foreground">
+                  {c.count} gift{c.count === 1 ? "" : "s"}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface LobbyBreakdownProps {
+  candidateId: string;
+  cycle?: number;
+}
+
+export function LobbyBreakdown({ candidateId, cycle = 2026 }: LobbyBreakdownProps) {
+  const [data, setData] = useState<LobbyBreakdownResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getCandidateLobbyBreakdown(candidateId, cycle)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidateId, cycle]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <p>Aggregating lobby contributions…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium text-foreground">Couldn't load lobby breakdown</p>
+            <p className="text-sm text-muted-foreground">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const maxAmount = data.lobbies.reduce((m, l) => Math.max(m, l.totalAmount), 0);
+  const anyMoney = maxAmount > 0;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h2 className="font-heading text-xl font-semibold text-foreground flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-primary" />
+            Industry & Lobby Breakdown
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            How much this candidate has received from major industry lobbies, classified from
+            itemized FEC filings for the {data.cycle} cycle.
+          </p>
+        </div>
+        {anyMoney && (
+          <div className="text-right shrink-0">
+            <p className="text-xs text-muted-foreground">Classified</p>
+            <p className="font-semibold text-foreground">
+              {formatCurrency(data.totalLobbyAmount)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {data.classifiedPercentage}% of receipts
+            </p>
+          </div>
+        )}
+      </div>
+
+      {anyMoney ? (
+        <div className="space-y-3">
+          {data.lobbies.map((bucket) => (
+            <LobbyRow key={bucket.id} bucket={bucket} maxAmount={maxAmount} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          No contributions matching tracked lobbies were found for this candidate yet.
+        </div>
+      )}
+
+      <div className="mt-4 flex items-start gap-2 text-xs text-muted-foreground">
+        <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          {data.notes.map((note, i) => (
+            <p key={i}>{note}</p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/CODE/src/components/candidates/index.ts
+++ b/CODE/src/components/candidates/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { CandidateCard } from './CandidateCard';
+export { LobbyBreakdown } from './LobbyBreakdown';

--- a/CODE/src/lib/api.ts
+++ b/CODE/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ApiError,
   CandidateFinanceResponse,
   DetailedFinanceResponse,
+  LobbyBreakdownResponse,
   Election,
   ElectionsResponse,
   GetElectionsParams,
@@ -210,6 +211,23 @@ export async function getCandidateDetailedFinances(
 
   const endpoint = `/candidates/${id}/finances/detailed?cycle=${cycle}`;
   return fetchAPI<DetailedFinanceResponse>(endpoint);
+}
+
+/**
+ * Get industry/lobby breakdown of donations for a candidate.
+ * Aggregates itemized FEC receipts into curated lobby buckets
+ * (AI / Big Tech, Oil & Gas, Pro-Israel, Pharma, Defense, Crypto, Labor).
+ */
+export async function getCandidateLobbyBreakdown(
+  id: string,
+  cycle: number = 2026
+): Promise<LobbyBreakdownResponse> {
+  if (!id || id.trim() === '') {
+    throw new Error('Candidate ID is required');
+  }
+
+  const endpoint = `/candidates/${id}/lobby-breakdown?cycle=${cycle}`;
+  return fetchAPI<LobbyBreakdownResponse>(endpoint);
 }
 
 /**

--- a/CODE/src/pages/Candidates.tsx
+++ b/CODE/src/pages/Candidates.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { getCandidateById, getCandidateDetailedFinances } from "@/lib/api";
 import type { Candidate, DetailedFinanceResponse } from "@/types/candidate";
+import { LobbyBreakdown } from "@/components/candidates/LobbyBreakdown";
 
 /**
  * Format currency amount to readable string
@@ -586,6 +587,9 @@ export default function Candidates() {
                       </div>
                     </div>
                   )}
+
+                  {/* Industry / Lobby Breakdown */}
+                  {id && <LobbyBreakdown candidateId={id} cycle={2026} />}
 
                   {/* Spending Categories */}
                   {spendingCategories.length > 0 && (

--- a/CODE/src/pages/Candidates.tsx
+++ b/CODE/src/pages/Candidates.tsx
@@ -473,6 +473,10 @@ export default function Candidates() {
 
             {/* Campaign Finance Tab */}
             <TabsContent value="funding" className="space-y-6">
+              {/* Industry / Lobby Breakdown — fetches independently so it
+                  renders even when detailed-finances data is missing. */}
+              {id && <LobbyBreakdown candidateId={id} cycle={2026} />}
+
               {financesLoading ? (
                 <div className="flex flex-col items-center justify-center py-12">
                   <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
@@ -587,9 +591,6 @@ export default function Candidates() {
                       </div>
                     </div>
                   )}
-
-                  {/* Industry / Lobby Breakdown */}
-                  {id && <LobbyBreakdown candidateId={id} cycle={2026} />}
 
                   {/* Spending Categories */}
                   {spendingCategories.length > 0 && (

--- a/CODE/src/pages/Candidates.tsx
+++ b/CODE/src/pages/Candidates.tsx
@@ -386,7 +386,7 @@ export default function Candidates() {
                     <div className="space-y-4">
                       <div className="text-center">
                         <span className="text-4xl font-bold text-foreground">
-                          {ideologyScore}
+                          {Math.round(ideologyScore)}
                         </span>
                         <span className="text-lg text-muted-foreground">/100</span>
                       </div>
@@ -655,7 +655,7 @@ export default function Candidates() {
                   <div className="mb-8">
                     <div className="text-center mb-4">
                       <span className="text-5xl font-bold text-foreground">
-                        {ideologyScore}
+                        {Math.round(ideologyScore)}
                       </span>
                       <span className="text-xl text-muted-foreground">/100</span>
                     </div>

--- a/CODE/src/pages/Candidates.tsx
+++ b/CODE/src/pages/Candidates.tsx
@@ -195,8 +195,9 @@ export default function Candidates() {
     fetchCandidateData();
   }, [id]);
 
-  // Get ideology score
-  const ideologyScore = candidate?.ideologyScores?.[0]?.ideologyScore;
+  // Get ideology score (latest congress session)
+  const ideologyData = candidate?.ideologyScores?.[0];
+  const ideologyScore = ideologyData?.ideologyScore;
 
   // Loading state
   if (loading) {
@@ -676,33 +677,70 @@ export default function Candidates() {
                   </div>
 
                   <div className="rounded-lg bg-muted/50 p-4">
-                    <h3 className="font-semibold text-foreground mb-2">Score Components</h3>
+                    <h3 className="font-semibold text-foreground mb-2">How it's computed</h3>
                     <ul className="text-sm text-muted-foreground space-y-1">
-                      <li>• Legislative voting patterns</li>
-                      <li>• Bill co-sponsorship analysis</li>
-                      <li>• Committee membership alignment</li>
-                      <li>• Historical voting record</li>
+                      <li>• Bill and resolution cosponsorship patterns</li>
+                      <li>• Position in the sponsorship network (who cosponsors with whom)</li>
+                      <li>• Calculated separately for the House and the Senate</li>
                     </ul>
                   </div>
 
-                  {/* Additional ideology data */}
-                  {candidate.ideologyScores && candidate.ideologyScores[0] && (
-                    <div className="mt-6 pt-6 border-t border-border">
-                      <h3 className="font-semibold text-foreground mb-4">Legislative Activity</h3>
-                      <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="rounded-lg bg-muted/30 p-4">
-                          <p className="text-sm text-muted-foreground">Bills Sponsored</p>
-                          <p className="text-2xl font-bold text-foreground">
-                            {candidate.ideologyScores[0].billsSponsored}
-                          </p>
-                        </div>
-                        <div className="rounded-lg bg-muted/30 p-4">
-                          <p className="text-sm text-muted-foreground">Bills Co-sponsored</p>
-                          <p className="text-2xl font-bold text-foreground">
-                            {candidate.ideologyScores[0].billsCosponsored}
-                          </p>
+                  {/* Leadership score + legislative activity (only what we have data for) */}
+                  {ideologyData &&
+                    (ideologyData.leadershipScore != null ||
+                      ideologyData.billsSponsored > 0 ||
+                      ideologyData.billsCosponsored > 0) && (
+                      <div className="mt-6 pt-6 border-t border-border">
+                        <h3 className="font-semibold text-foreground mb-4">Legislative Influence</h3>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          {ideologyData.leadershipScore != null && (
+                            <div className="rounded-lg bg-muted/30 p-4">
+                              <p className="text-sm text-muted-foreground">Leadership Score</p>
+                              <p className="text-2xl font-bold text-foreground">
+                                {ideologyData.leadershipScore.toFixed(2)}
+                              </p>
+                              <p className="text-xs text-muted-foreground mt-1">
+                                Higher = a more central, influential bill sponsor.
+                              </p>
+                            </div>
+                          )}
+                          {ideologyData.billsSponsored > 0 && (
+                            <div className="rounded-lg bg-muted/30 p-4">
+                              <p className="text-sm text-muted-foreground">Bills Sponsored</p>
+                              <p className="text-2xl font-bold text-foreground">
+                                {ideologyData.billsSponsored}
+                              </p>
+                            </div>
+                          )}
+                          {ideologyData.billsCosponsored > 0 && (
+                            <div className="rounded-lg bg-muted/30 p-4">
+                              <p className="text-sm text-muted-foreground">Bills Co-sponsored</p>
+                              <p className="text-2xl font-bold text-foreground">
+                                {ideologyData.billsCosponsored}
+                              </p>
+                            </div>
+                          )}
                         </div>
                       </div>
+                    )}
+
+                  {/* Methodology disclosure & source attribution (PRD 3.4.3) */}
+                  {ideologyData && (
+                    <div className="mt-6 pt-6 border-t border-border space-y-1 text-xs text-muted-foreground">
+                      <p>
+                        Source: GovTrack.us cosponsorship analysis, Congress{" "}
+                        {ideologyData.congressSession}.
+                      </p>
+                      <p>
+                        Last calculated:{" "}
+                        {new Date(ideologyData.calculatedAt).toLocaleDateString()}.
+                      </p>
+                      <p>
+                        Non-partisan, data-derived estimate of relative position from
+                        cosponsorship patterns — not an endorsement or a measure of
+                        effectiveness. Shown only for candidates with a congressional
+                        voting record.
+                      </p>
                     </div>
                   )}
                 </div>

--- a/CODE/src/types/candidate.ts
+++ b/CODE/src/types/candidate.ts
@@ -221,6 +221,45 @@ export interface DetailedFinanceResponse {
 }
 
 /**
+ * Top contributor inside a lobby bucket
+ */
+export interface LobbyContributor {
+  name: string;
+  employer: string | null;
+  amount: number;
+  count: number;
+}
+
+/**
+ * One industry/lobby bucket in the candidate's lobby breakdown
+ */
+export interface LobbyBucket {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  totalAmount: number;
+  contributionCount: number;
+  percentageOfReceipts: number;
+  topContributors: LobbyContributor[];
+}
+
+/**
+ * Full lobby/industry breakdown response for a candidate
+ */
+export interface LobbyBreakdownResponse {
+  candidateId: string;
+  candidateName: string;
+  cycle: number;
+  totalReceipts: number;
+  totalLobbyAmount: number;
+  classifiedPercentage: number;
+  lobbies: LobbyBucket[];
+  lastComputed: string;
+  notes: string[];
+}
+
+/**
  * Election information
  */
 export interface Election {

--- a/PHASE5_PLAN.md
+++ b/PHASE5_PLAN.md
@@ -1,0 +1,100 @@
+# Phase 5 — Donor & Lobby Breakdown per Candidate
+
+Goal: every candidate page should let a voter see, at a glance, **how much
+money the candidate has accepted from major industry lobbies** (AI, Oil &
+Gas, Pro-Israel, Pharma, Defense, Crypto, Labor) — in addition to the
+existing top-donor list.
+
+All work happens directly on the `phase5` branch.
+
+## What ships in this phase
+
+### Backend (`/backend`)
+
+1. **Lobby taxonomy** — `src/data/lobbies.ts`
+   - Hand-curated list of lobby buckets with three matchers each:
+     - `committeeIds` — known FEC committee IDs (kept for future use)
+     - `namePatterns` — case-insensitive regex against `Receipt.contributorName`
+       (catches PAC contributions where the contributor IS the PAC)
+     - `employerPatterns` — case-insensitive regex against
+       `Receipt.contributorEmployer` (catches industry-employed individual donors)
+   - Seeded with: AI / Big Tech, Oil & Gas, Pro-Israel, Pharma & Health
+     Products, Defense & Aerospace, Crypto & Blockchain, Organized Labor.
+
+2. **LobbyService** — `src/services/lobby.service.ts`
+   - `getLobbyCatalog()` — returns the static list (id, name, description, color).
+   - `getLobbyBreakdown(candidateDbId, cycle)` —
+     1. Resolve candidate → committees.
+     2. Pre-filter `Receipt` rows in SQL via a single `OR` of `ILIKE`
+        substrings (one per pattern), scoped to the cycle date window
+        `[cycle-1, cycle]`. This is just a coarse pre-filter so we don't
+        scan tens of thousands of receipts in JS.
+     3. Run real regex matching in JS to bucket each receipt into a lobby.
+     4. Compute per-lobby totals, contribution counts, and top 5
+        contributors per lobby.
+     5. Compute `totalReceipts` (cycle-windowed aggregate) for context
+        and `classifiedPercentage` of receipts that fell into a lobby.
+
+3. **API endpoints** (`src/controllers/candidate.controller.ts`,
+   `src/routes/candidates.routes.ts`, `src/routes/index.ts`)
+   - `GET /api/candidates/:id/lobby-breakdown?cycle=2026` — full breakdown.
+   - `GET /api/lobbies` — static catalog (for legends / future filters).
+
+### Frontend (`/CODE`)
+
+1. **Types & API client**
+   - `src/types/candidate.ts` — adds `LobbyContributor`, `LobbyBucket`,
+     `LobbyBreakdownResponse`.
+   - `src/lib/api.ts` — adds `getCandidateLobbyBreakdown(id, cycle)`.
+
+2. **`LobbyBreakdown` component**
+   - `src/components/candidates/LobbyBreakdown.tsx`
+   - Card with one row per lobby, sorted by total amount.
+   - Each row shows:
+     - Color dot, lobby name, short description
+     - `$total received` and `% of receipts` on the right
+     - A horizontal bar (relative to the largest bucket in the breakdown)
+     - Click-to-expand reveals the **top 5 contributors in that lobby**
+       with their employer + dollar amount + count of gifts
+   - Header summary: `classified $ / % of receipts` for the candidate.
+   - Inline disclaimer notes (under-$200 individual gifts not itemized,
+     employer self-reporting limitations).
+   - Empty / loading / error states all handled.
+
+3. **Wired into the existing candidate profile page**
+   - `src/pages/Candidates.tsx` — inside the existing **Campaign Finance**
+     tab, slotted between *Top Contributors* and *Spending Breakdown*.
+   - Loads lazily (its own `useEffect`) so the rest of the finance tab
+     renders immediately.
+
+## Design notes / tradeoffs
+
+- **Coverage is conservative.** The lobby lists are hand-curated — total
+  numbers will undercount, never overcount. Easy to extend by editing
+  `backend/src/data/lobbies.ts`.
+- **No new database columns / migrations.** The aggregation runs against
+  the existing `Receipt` table and is computed on demand. If this gets
+  slow we can cache results in a `LobbyAggregate` table keyed on
+  `(candidateId, cycle)` and refresh on the existing weekly sync.
+- **No OpenSecrets dependency.** Their bulk industry codes (CRP IDs)
+  would give broader coverage, but require registration and license
+  compliance. We can layer them in later behind the same service shape.
+- **Cycle filter uses `contributionReceiptDate` window** (`[cycle-1, cycle]`)
+  rather than a stored cycle column on the receipt. Existing detailed
+  finances code does not filter by cycle at all — the lobby breakdown
+  is actually stricter on this dimension.
+- **Pro-Israel bucket** is name-pattern only by design (employer-pattern
+  matching for it produces too many false positives — e.g. anyone employed
+  by an Israeli-headquartered tech firm).
+
+## Future extensions (not in this phase)
+
+- Persist a precomputed `LobbyAggregate` table refreshed by the
+  weekly FEC sync job, so the endpoint is O(lobbies) rather than scanning
+  receipts on every request.
+- Add a **filter on the candidates list page** to find candidates with
+  the highest take from a given lobby ("Show me Senate candidates ranked
+  by Oil & Gas dollars").
+- Pull in OpenSecrets CRP industry codes for finer industry coverage.
+- Surface lobby badges on the `CandidateCard` (e.g. "Top recipient of AI
+  lobby money in CA").

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,11 @@ NODE_ENV=development
 
 # Rate Limiting
 FEC_API_MAX_REQUESTS_PER_HOUR=120
+
+# Ideology scoring (GovTrack-based) — see IDEOLOGY_SYNC.md and `npm run sync:ideology`.
+# Defaults are fine for most setups; override only to pin a Congress or proxy the
+# data hosts. The sync host (govtrack.us) and crosswalk host
+# (raw.githubusercontent.com) must be reachable / allowlisted for egress.
+IDEOLOGY_CONGRESS=119
+IDEOLOGY_GOVTRACK_BASE_URL=https://www.govtrack.us/data/analysis/by-congress
+IDEOLOGY_LEGISLATORS_URL=https://raw.githubusercontent.com/unitedstates/congress-legislators/main/legislators-current.yaml

--- a/backend/IDEOLOGY_SYNC.md
+++ b/backend/IDEOLOGY_SYNC.md
@@ -1,0 +1,85 @@
+# Ideology Scoring Sync (issue #33)
+
+Populates the `IdeologyScore` table with **GovTrack-based ideology and
+leadership scores** for sitting members of Congress, which powers the
+"Ideology Score" spectrum on candidate profiles (PRD §3.4).
+
+Before this sync existed, the `IdeologyScore` table was never written to, so the
+ideology UI was dead code for every candidate. Running this brings it to life.
+
+## What it does
+
+```
+FEC candidate IDs (our DB)
+        │
+        │  unitedstates/congress-legislators crosswalk
+        ▼
+GovTrack person IDs
+        │
+        │  GovTrack sponsorship-analysis (House + Senate)
+        ▼
+ideology + leadership scores  ──►  upsert into IdeologyScore
+```
+
+1. **Crosswalk** — fetches `legislators-current.yaml` and builds a map of
+   FEC candidate ID → GovTrack person ID. Only *current* members appear here,
+   which is exactly the set that has a voting record to score.
+2. **Scores** — fetches GovTrack's per-Congress `sponsorshipanalysis_h.txt` and
+   `sponsorshipanalysis_s.txt`, which contain an ideology score (0 = most
+   liberal/left, 1 = most conservative/right) and a leadership score per member.
+3. **Join + upsert** — for each candidate whose FEC ID resolves to a GovTrack
+   member with a score, upserts one `IdeologyScore` row keyed on
+   `(candidateId, congressSession)`.
+
+Implementation: [`src/services/ideology.service.ts`](src/services/ideology.service.ts),
+runnable via [`src/scripts/sync-ideology.ts`](src/scripts/sync-ideology.ts).
+
+## Running it
+
+```bash
+# Uses IDEOLOGY_CONGRESS from env (default 119)
+npm run sync:ideology
+
+# Or pin a specific Congress
+npm run sync:ideology -- --congress 119
+```
+
+Requires:
+- A reachable `DATABASE_URL`.
+- **Network egress** to `www.govtrack.us` and `raw.githubusercontent.com`
+  (hosts configurable via `IDEOLOGY_GOVTRACK_BASE_URL` / `IDEOLOGY_LEGISLATORS_URL`).
+  In locked-down/allowlisted environments these two hosts must be permitted.
+
+The script exits non-zero if **zero** scores were written, so a cron/CI run will
+surface a broken upstream source or an empty database.
+
+## Scheduling
+
+Ideology data changes slowly; the PRD calls for monthly refreshes. Run it on a
+monthly cron (e.g. a Railway scheduled job) with the same env as the app:
+
+```
+npm run sync:ideology
+```
+
+It is safe to re-run — upserts are idempotent per `(candidateId, congressSession)`.
+
+## Scale & storage notes
+
+- GovTrack's raw ideology is `0..1`. We store it **scaled to `0..100`**
+  (0 = progressive/left, 100 = conservative/right) so the existing frontend
+  spectrum renders without per-component conversion.
+- `leadershipScore` is stored as GovTrack reports it (not a percentage).
+- `billsSponsored` / `billsCosponsored` are **not** populated yet — GovTrack's
+  sponsorship-analysis file doesn't include raw counts. The columns default to
+  `0` and the UI hides them until a source is wired in (see below). This is the
+  remaining gap vs. the full issue #33 "scorecard".
+
+## Extending (future)
+
+- **Bill counts & key votes**: pull from the Congress.gov API (the supported
+  successor to the ProPublica Congress API) keyed by bioguide ID, which the same
+  crosswalk already provides.
+- **Voting participation rate**: also available from Congress.gov member data.
+- **Comparisons** (party / state-delegation averages, PRD §3.4.2): compute from
+  the populated `IdeologyScore` rows.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^4.2.1",
         "prisma": "^6.1.0",
+        "yaml": "^2.9.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -2261,6 +2262,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "sync:financials": "tsx src/scripts/sync-financials-only.ts",
     "sync:financials:force": "tsx src/scripts/sync-financials-only.ts --force",
     "sync:financials:fast": "tsx src/scripts/sync-financials-only.ts --batch-size 100",
+    "sync:ideology": "tsx src/scripts/sync-ideology.ts",
     "admin:create": "tsx src/scripts/create-admin.ts",
     "researcher:create": "tsx src/scripts/create-researcher.ts",
     "seed:counties": "tsx src/scripts/seed-counties.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,6 +49,7 @@
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^4.2.1",
     "prisma": "^6.1.0",
+    "yaml": "^2.9.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -13,6 +13,24 @@ const envSchema = z.object({
   FEC_API_MAX_REQUESTS_PER_HOUR: z.string().default('120'),
   ADMIN_PASSWORD: z.string().optional(),
   RESEARCHER_JWT_SECRET: z.string().default('dev-researcher-secret-change-me'),
+
+  // Ideology scoring (GovTrack-based) data sources — see src/services/ideology.service.ts
+  // The Congress whose voting/cosponsorship record powers incumbent ideology scores.
+  // The 119th Congress (2025-2027) is the one sitting during the 2026 midterm cycle.
+  IDEOLOGY_CONGRESS: z.string().default('119'),
+  // GovTrack publishes per-Congress sponsorship-analysis files (ideology + leadership
+  // scores derived from cosponsorship networks) under this base path, as
+  //   {BASE}/{congress}/sponsorshipanalysis_{h|s}.txt
+  IDEOLOGY_GOVTRACK_BASE_URL: z
+    .string()
+    .default('https://www.govtrack.us/data/analysis/by-congress'),
+  // The unitedstates/congress-legislators crosswalk maps FEC candidate IDs to
+  // GovTrack person IDs so we can join GovTrack scores onto our FEC-keyed candidates.
+  IDEOLOGY_LEGISLATORS_URL: z
+    .string()
+    .default(
+      'https://raw.githubusercontent.com/unitedstates/congress-legislators/main/legislators-current.yaml'
+    ),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -26,4 +44,5 @@ export const env = {
   ...parsed.data,
   PORT: parseInt(parsed.data.PORT, 10),
   FEC_API_MAX_REQUESTS_PER_HOUR: parseInt(parsed.data.FEC_API_MAX_REQUESTS_PER_HOUR, 10),
+  IDEOLOGY_CONGRESS: parseInt(parsed.data.IDEOLOGY_CONGRESS, 10),
 };

--- a/backend/src/controllers/candidate.controller.ts
+++ b/backend/src/controllers/candidate.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { candidateService } from '../services/candidate.service.js';
 import { financeService } from '../services/finance.service.js';
+import { lobbyService } from '../services/lobby.service.js';
 
 export class CandidateController {
   /**
@@ -153,6 +154,43 @@ export class CandidateController {
       }
       
       res.status(500).json({ error: 'Failed to fetch detailed finances', message: error.message });
+    }
+  }
+
+  /**
+   * GET /api/candidates/:id/lobby-breakdown
+   * Aggregate the candidate's itemized receipts into industry / lobby buckets
+   * (AI, Oil & Gas, Pro-Israel, Pharma, Defense, Crypto, Labor).
+   */
+  async getCandidateLobbyBreakdown(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { cycle } = req.query;
+      const cycleNum = cycle ? parseInt(cycle as string) : 2026;
+
+      const breakdown = await lobbyService.getLobbyBreakdown(id, cycleNum);
+      res.json(breakdown);
+    } catch (error: any) {
+      console.error('Error getting lobby breakdown:', error);
+
+      if (error.message === 'Candidate not found') {
+        res.status(404).json({ error: 'Candidate not found' });
+        return;
+      }
+
+      res.status(500).json({ error: 'Failed to compute lobby breakdown', message: error.message });
+    }
+  }
+
+  /**
+   * GET /api/lobbies
+   * Static catalog of supported lobbies (used by UI legends).
+   */
+  async getLobbyCatalog(_req: Request, res: Response): Promise<void> {
+    try {
+      res.json({ lobbies: lobbyService.getLobbyCatalog() });
+    } catch (error: any) {
+      res.status(500).json({ error: 'Failed to fetch lobby catalog', message: error.message });
     }
   }
 

--- a/backend/src/data/lobbies.ts
+++ b/backend/src/data/lobbies.ts
@@ -35,14 +35,15 @@ export const LOBBIES: LobbyDefinition[] = [
       'C00428235', // Google Inc. NetPAC
       'C00487777', // Microsoft Corp PAC
       'C00428912', // Amazon.com PAC
-      'C00819872', // Fairshake (crypto+tech aligned)
       'C00770273', // Meta Platforms PAC
       'C00838526', // Leading the Future (AI policy super PAC)
+      // Fairshake (C00819872) is intentionally NOT here — it's
+      // overwhelmingly crypto-funded, so it lives only under the
+      // `crypto` lobby below. matchLobby is first-match-wins.
     ],
     namePatterns: [
       'leading the future',
       'americans for ai',
-      'fairshake',
       'google.*pac',
       'microsoft.*pac',
       'alphabet inc',

--- a/backend/src/data/lobbies.ts
+++ b/backend/src/data/lobbies.ts
@@ -1,0 +1,338 @@
+/**
+ * Industry / lobby classification for FEC contributions.
+ *
+ * For each lobby we match Receipt rows three ways:
+ *   - committeeIds: exact FEC committee ID of a contributing PAC
+ *   - namePatterns: case-insensitive regex against contributorName
+ *     (catches PAC contributions where the contributor IS the PAC)
+ *   - employerPatterns: case-insensitive regex against contributorEmployer
+ *     (catches individual donors employed by industry firms)
+ *
+ * Sources: FEC.gov public committee filings, OpenSecrets industry
+ * classifications (CRP codes — public reference), major-employer lists.
+ *
+ * Intentionally conservative — totals will undercount but should not
+ * overcount. Update the lists below to expand coverage.
+ */
+export interface LobbyDefinition {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  committeeIds: string[];
+  namePatterns: string[];
+  employerPatterns: string[];
+}
+
+export const LOBBIES: LobbyDefinition[] = [
+  {
+    id: 'ai',
+    name: 'AI / Big Tech',
+    description:
+      'Artificial intelligence companies, model labs, and the largest cloud/compute providers backing AI policy.',
+    color: '#8b5cf6',
+    committeeIds: [
+      'C00428235', // Google Inc. NetPAC
+      'C00487777', // Microsoft Corp PAC
+      'C00428912', // Amazon.com PAC
+      'C00819872', // Fairshake (crypto+tech aligned)
+      'C00770273', // Meta Platforms PAC
+      'C00838526', // Leading the Future (AI policy super PAC)
+    ],
+    namePatterns: [
+      'leading the future',
+      'americans for ai',
+      'fairshake',
+      'google.*pac',
+      'microsoft.*pac',
+      'alphabet inc',
+      'meta platforms.*pac',
+      'amazon\\.com.*pac',
+      'nvidia.*pac',
+      'ibm.*pac',
+      'oracle.*pac',
+      'salesforce.*pac',
+    ],
+    employerPatterns: [
+      'openai',
+      'anthropic',
+      'google',
+      'alphabet',
+      'deepmind',
+      'microsoft',
+      'meta platforms',
+      'facebook',
+      'nvidia',
+      'amazon',
+      'amazon web services',
+      '\\baws\\b',
+      'apple inc',
+      'oracle',
+      '\\bibm\\b',
+      'salesforce',
+      'scale ai',
+      'perplexity',
+      'mistral',
+      'cohere',
+      'databricks',
+      'palantir',
+      'huggingface',
+      'hugging face',
+      'stability ai',
+      '\\bxai\\b',
+      'x\\.ai',
+    ],
+  },
+  {
+    id: 'oil_gas',
+    name: 'Oil & Gas',
+    description:
+      'Oil majors, independents, refiners, pipeline operators, and their trade-association PACs.',
+    color: '#1f2937',
+    committeeIds: [
+      'C00126774', // Chevron Employees PAC
+      'C00012245', // ExxonMobil PAC
+      'C00041681', // ConocoPhillips SPIRIT PAC
+      'C00177439', // Marathon Petroleum Corp Employees PAC
+      'C00033710', // Halliburton Co PAC
+      'C00078451', // Koch Industries PAC (KOCHPAC)
+      'C00114531', // American Petroleum Institute PAC
+      'C00263601', // Independent Petroleum Assn of America PAC
+      'C00107477', // Occidental Petroleum Corp PAC
+      'C00193337', // Valero Energy Corp PAC
+    ],
+    namePatterns: [
+      'exxon.*pac',
+      'chevron.*pac',
+      'conocophillips.*pac',
+      'occidental.*pac',
+      'marathon.*pac',
+      'valero.*pac',
+      'phillips 66.*pac',
+      'halliburton.*pac',
+      'schlumberger.*pac',
+      'koch industries.*pac',
+      'energy transfer.*pac',
+      'kinder morgan.*pac',
+      'enterprise products.*pac',
+      'american petroleum institute',
+      '\\bapi pac\\b',
+      'ipaa pac',
+      'independent petroleum',
+    ],
+    employerPatterns: [
+      'exxon',
+      'exxonmobil',
+      'chevron',
+      'conocophillips',
+      'occidental petroleum',
+      'marathon petroleum',
+      'marathon oil',
+      'valero',
+      'phillips 66',
+      'shell oil',
+      'shell usa',
+      'halliburton',
+      'schlumberger',
+      'baker hughes',
+      'koch industries',
+      'energy transfer',
+      'kinder morgan',
+      'enterprise products',
+      'pioneer natural',
+      'devon energy',
+      'eog resources',
+      'hess corporation',
+      'american petroleum institute',
+    ],
+  },
+  {
+    id: 'pro_israel',
+    name: 'Pro-Israel',
+    description:
+      'PACs and organizations that explicitly advocate U.S.-Israel policy alignment. Includes both bipartisan and partisan-leaning groups.',
+    color: '#0ea5e9',
+    committeeIds: [
+      'C00797670', // United Democracy Project (AIPAC-affiliated super PAC)
+      'C00127811', // AIPAC PAC
+      'C00734301', // Democratic Majority for Israel
+      'C00528081', // Republican Jewish Coalition PAC
+      'C00130377', // NORPAC
+      'C00368856', // Pro-Israel America PAC
+      'C00497915', // To Protect Our Heritage PAC
+      'C00136473', // Joint Action Committee for Political Affairs (JACPAC)
+      'C00098699', // Washington PAC
+      'C00499945', // Hudson Valley PAC
+    ],
+    namePatterns: [
+      '\\baipac\\b',
+      'united democracy project',
+      'democratic majority for israel',
+      'republican jewish coalition',
+      'norpac',
+      'jacpac',
+      'pro-israel america',
+      'to protect our heritage',
+      'joint action committee for political affairs',
+      'florida congressional committee',
+      'hudson valley pac',
+      'desert caucus',
+      'washington pac',
+    ],
+    employerPatterns: [],
+  },
+  {
+    id: 'pharma',
+    name: 'Pharma & Health Products',
+    description: 'Pharmaceutical manufacturers, biotech firms, and PhRMA-affiliated PACs.',
+    color: '#ef4444',
+    committeeIds: [
+      'C00081496', // Pfizer Inc PAC
+      'C00043604', // Merck & Co Inc PAC
+      'C00025260', // Eli Lilly & Co PAC
+      'C00131110', // Johnson & Johnson PAC
+      'C00141788', // AbbVie Inc PAC
+      'C00248818', // Amgen Inc PAC
+      'C00345366', // PhRMA PAC
+    ],
+    namePatterns: [
+      'pfizer.*pac',
+      'merck.*pac',
+      'eli lilly.*pac',
+      'johnson & johnson.*pac',
+      'abbvie.*pac',
+      'bristol.*myers.*pac',
+      'amgen.*pac',
+      'novartis.*pac',
+      'gilead.*pac',
+      'phrma pac',
+      'biotechnology innovation',
+    ],
+    employerPatterns: [
+      'pfizer',
+      'merck',
+      'eli lilly',
+      'johnson & johnson',
+      'abbvie',
+      'bristol-myers',
+      'bristol myers squibb',
+      'amgen',
+      'novartis',
+      'gilead',
+      'regeneron',
+      'moderna',
+      'biontech',
+      'sanofi',
+      'astrazeneca',
+      'glaxosmithkline',
+      '\\bgsk\\b',
+      'phrma',
+    ],
+  },
+  {
+    id: 'defense',
+    name: 'Defense & Aerospace',
+    description: 'Major defense contractors and aerospace manufacturers with federal contracts.',
+    color: '#475569',
+    committeeIds: [
+      'C00277345', // Lockheed Martin Employees PAC
+      'C00010057', // Boeing Co PAC
+      'C00146574', // Raytheon Co PAC (RTX)
+      'C00034298', // Northrop Grumman Corp PAC
+      'C00224946', // General Dynamics Voluntary Political Contribution Plan
+      'C00134290', // L3Harris Technologies PAC
+    ],
+    namePatterns: [
+      'lockheed martin.*pac',
+      'boeing.*pac',
+      'raytheon.*pac',
+      'rtx.*pac',
+      'northrop grumman.*pac',
+      'general dynamics.*pac',
+      'l3harris.*pac',
+      'huntington ingalls.*pac',
+      'leidos.*pac',
+    ],
+    employerPatterns: [
+      'lockheed martin',
+      'boeing',
+      'raytheon',
+      'rtx corp',
+      'northrop grumman',
+      'general dynamics',
+      'l3harris',
+      'huntington ingalls',
+      'leidos',
+      'booz allen',
+      '\\bsaic\\b',
+      'anduril',
+    ],
+  },
+  {
+    id: 'crypto',
+    name: 'Crypto & Blockchain',
+    description: 'Cryptocurrency exchanges, blockchain firms, and major crypto-aligned PACs.',
+    color: '#f59e0b',
+    committeeIds: [
+      'C00819872', // Fairshake
+      'C00835959', // Defend American Jobs
+      'C00836155', // Protect Progress
+      'C00805954', // Crypto Innovation PAC
+    ],
+    namePatterns: [
+      'fairshake',
+      'defend american jobs',
+      'protect progress',
+      'coinbase.*pac',
+      'kraken.*pac',
+      'ripple.*pac',
+    ],
+    employerPatterns: [
+      'coinbase',
+      'kraken',
+      'ripple',
+      'circle internet',
+      'binance',
+      'gemini trust',
+      'andreessen horowitz',
+      '\\ba16z\\b',
+      'polygon labs',
+      'consensys',
+      'uniswap',
+    ],
+  },
+  {
+    id: 'labor',
+    name: 'Organized Labor',
+    description: 'Major labor unions and their political committees.',
+    color: '#10b981',
+    committeeIds: [
+      'C00004036', // AFL-CIO COPE
+      'C00004606', // SEIU COPE
+      'C00010132', // AFSCME PEOPLE
+      'C00026789', // UAW V-CAP
+      'C00036214', // Teamsters DRIVE
+      'C00010561', // NEA Fund for Children & Public Education
+      'C00177436', // American Federation of Teachers (AFT) Committee on Political Education
+      'C00345057', // IBEW PAC
+    ],
+    namePatterns: [
+      'afl-cio',
+      'afl cio',
+      'seiu cope',
+      'afscme pac',
+      'afscme people',
+      '\\buaw\\b',
+      'teamsters drive',
+      'national education association',
+      'nea fund',
+      'american federation of teachers',
+      'aft committee',
+      'carpenters legislative',
+      'ibew pac',
+      'ufcw active ballot',
+      'machinists non-partisan',
+    ],
+    employerPatterns: [],
+  },
+];

--- a/backend/src/jobs/scheduler.ts
+++ b/backend/src/jobs/scheduler.ts
@@ -10,6 +10,7 @@ import cron from 'node-cron';
 import { prisma } from '../config/database.js';
 import { candidateService } from '../services/candidate.service.js';
 import { financeService } from '../services/finance.service.js';
+import { syncIdeologyScores } from '../services/ideology.service.js';
 
 // Configuration for scheduled syncs
 const SYNC_CONFIG = {
@@ -291,6 +292,27 @@ export function initializeScheduler(): void {
 
   console.log('⏰ FEC Data Sync Scheduler initialized');
   console.log(`📅 Schedule: Every Sunday, Tuesday, Thursday at 2:00 AM EST\n`);
+
+  // Ideology scores change slowly (PRD calls for monthly refresh). Run on the
+  // 1st of each month, independently of the FEC sync. Isolated and idempotent —
+  // a failure here (e.g. blocked egress) is logged and never affects FEC syncs.
+  const ideologyCron = '0 3 1 * *'; // 1st of the month, 3:00 AM
+  if (cron.validate(ideologyCron)) {
+    cron.schedule(
+      ideologyCron,
+      async () => {
+        console.log('\n⏰ Scheduled ideology sync triggered');
+        try {
+          await syncIdeologyScores();
+        } catch (error) {
+          console.error('❌ Scheduled ideology sync failed:', error);
+        }
+      },
+      { timezone: 'America/New_York' }
+    );
+    console.log('🧭 Ideology Sync Scheduler initialized');
+    console.log(`📅 Schedule: 1st of each month at 3:00 AM EST\n`);
+  }
 }
 
 /**

--- a/backend/src/routes/candidates.routes.ts
+++ b/backend/src/routes/candidates.routes.ts
@@ -15,6 +15,9 @@ router.get('/:id', (req, res) => candidateController.getCandidateById(req, res))
 // Get detailed candidate finances (funding sources, top donors, spending categories)
 router.get('/:id/finances/detailed', (req, res) => candidateController.getCandidateDetailedFinances(req, res));
 
+// Get lobby/industry breakdown of donations for this candidate
+router.get('/:id/lobby-breakdown', (req, res) => candidateController.getCandidateLobbyBreakdown(req, res));
+
 // Get candidate finances (basic summary)
 router.get('/:id/finances', (req, res) => candidateController.getCandidateFinances(req, res));
 

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import deadlinesRoutes from './deadlines.routes.js';
 import chatRoutes from './chat.routes.js';
 import researcherAuthRoutes from './researcher-auth.routes.js';
 import researchRoutes from './research.routes.js';
+import { candidateController } from '../controllers/candidate.controller.js';
 import { prisma } from '../config/database.js';
 
 const router = Router();
@@ -20,6 +21,9 @@ router.use('/deadlines', deadlinesRoutes);
 router.use('/chat', chatRoutes);
 router.use('/auth/researcher', researcherAuthRoutes);
 router.use('/research', researchRoutes);
+
+// Static catalog of supported lobbies (for UI legends/filters)
+router.get('/lobbies', (req, res) => candidateController.getLobbyCatalog(req, res));
 
 // Health check endpoint
 router.get('/health', async (_req, res) => {

--- a/backend/src/scripts/sync-ideology.ts
+++ b/backend/src/scripts/sync-ideology.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+/**
+ * Sync GovTrack-based ideology scores (issue #33).
+ *
+ * Populates the IdeologyScore table for sitting members so candidate profiles
+ * can show the "Ideology Score" spectrum. See src/services/ideology.service.ts.
+ *
+ * Requires network egress to the GovTrack + congress-legislators hosts
+ * (configurable via IDEOLOGY_GOVTRACK_BASE_URL / IDEOLOGY_LEGISLATORS_URL) and
+ * a reachable DATABASE_URL.
+ *
+ * Usage:
+ *   tsx src/scripts/sync-ideology.ts [--congress 119]
+ *   npm run sync:ideology -- --congress 119
+ */
+
+import { prisma } from '../config/database.js';
+import { env } from '../config/env.js';
+import { syncIdeologyScores } from '../services/ideology.service.js';
+
+function parseCongressArg(): number {
+  const idx = process.argv.indexOf('--congress');
+  if (idx !== -1 && process.argv[idx + 1]) {
+    const parsed = parseInt(process.argv[idx + 1], 10);
+    if (Number.isFinite(parsed)) return parsed;
+    console.warn(`⚠️  Ignoring invalid --congress value: ${process.argv[idx + 1]}`);
+  }
+  return env.IDEOLOGY_CONGRESS;
+}
+
+async function main(): Promise<void> {
+  const congress = parseCongressArg();
+  try {
+    const stats = await syncIdeologyScores(congress);
+    await prisma.$disconnect();
+    // Non-zero exit if nothing was scored, so CI/cron surfaces a broken source.
+    process.exit(stats.scored > 0 ? 0 : 1);
+  } catch (error) {
+    console.error('❌ Ideology sync failed:', error);
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+}
+
+main();

--- a/backend/src/services/ideology.service.ts
+++ b/backend/src/services/ideology.service.ts
@@ -22,6 +22,7 @@
 import axios from 'axios';
 import { parse as parseCsv } from 'csv-parse/sync';
 import { parse as parseYaml } from 'yaml';
+import { prisma } from '../config/database.js';
 import { env } from '../config/env.js';
 
 /**
@@ -165,4 +166,106 @@ export async function fetchGovtrackAnalysis(
 
   console.log(`📊 GovTrack analysis: ${map.size} members for Congress ${congress}`);
   return map;
+}
+
+export interface IdeologySyncStats {
+  congress: number;
+  candidatesTotal: number;
+  matchedCrosswalk: number;
+  scored: number;
+  skippedNoCrosswalk: number;
+  skippedNoScore: number;
+  durationMs: number;
+}
+
+/**
+ * Convert GovTrack's raw 0..1 ideology score to the 0..100 scale the frontend
+ * spectrum expects (0 = most progressive/left, 100 = most conservative/right),
+ * rounded to two decimals. Storing on the 0..100 scale keeps every existing UI
+ * consumer correct without per-component conversion.
+ */
+function toStoredIdeology(ideology: number): number {
+  return Math.round(ideology * 100 * 100) / 100;
+}
+
+/**
+ * Sync GovTrack ideology + leadership scores into the IdeologyScore table.
+ *
+ * Only candidates whose FEC ID appears in the (current-members) crosswalk and
+ * who have a GovTrack score get a row — i.e. sitting members with a voting
+ * record — which is exactly the set the PRD says should show an ideology score.
+ */
+export async function syncIdeologyScores(
+  congress: number = env.IDEOLOGY_CONGRESS
+): Promise<IdeologySyncStats> {
+  const startedAt = Date.now();
+  console.log(`\n🧭 Starting ideology sync for Congress ${congress}\n`);
+
+  const [crosswalk, scoreMap] = await Promise.all([
+    fetchFecToGovtrackCrosswalk(),
+    fetchGovtrackAnalysis(congress),
+  ]);
+
+  const candidates = await prisma.candidate.findMany({
+    select: { candidateId: true, name: true },
+  });
+
+  const stats: IdeologySyncStats = {
+    congress,
+    candidatesTotal: candidates.length,
+    matchedCrosswalk: 0,
+    scored: 0,
+    skippedNoCrosswalk: 0,
+    skippedNoScore: 0,
+    durationMs: 0,
+  };
+
+  for (const candidate of candidates) {
+    const govtrackId = crosswalk.get(candidate.candidateId);
+    if (govtrackId == null) {
+      stats.skippedNoCrosswalk++;
+      continue;
+    }
+    stats.matchedCrosswalk++;
+
+    const score = scoreMap.get(govtrackId);
+    if (!score || score.ideology == null) {
+      stats.skippedNoScore++;
+      continue;
+    }
+
+    const ideologyScore = toStoredIdeology(score.ideology);
+    const leadershipScore = score.leadership ?? null;
+
+    await prisma.ideologyScore.upsert({
+      where: {
+        candidateId_congressSession: {
+          candidateId: candidate.candidateId,
+          congressSession: congress,
+        },
+      },
+      update: { ideologyScore, leadershipScore, calculatedAt: new Date() },
+      create: {
+        candidateId: candidate.candidateId,
+        congressSession: congress,
+        ideologyScore,
+        leadershipScore,
+      },
+    });
+    stats.scored++;
+  }
+
+  stats.durationMs = Date.now() - startedAt;
+
+  console.log(
+    `\n🧭 Ideology sync complete for Congress ${congress}:\n` +
+      `   candidates: ${stats.candidatesTotal}\n` +
+      `   matched in crosswalk: ${stats.matchedCrosswalk}\n` +
+      `   scored (upserted): ${stats.scored}\n` +
+      `   skipped (no crosswalk / not a sitting member): ${stats.skippedNoCrosswalk}\n` +
+      `   skipped (in crosswalk but no GovTrack score): ${stats.skippedNoScore}\n` +
+      `   took ${(stats.durationMs / 1000).toFixed(1)}s\n`
+  );
+
+  return stats;
 }

--- a/backend/src/services/ideology.service.ts
+++ b/backend/src/services/ideology.service.ts
@@ -20,6 +20,7 @@
  */
 
 import axios from 'axios';
+import { parse as parseCsv } from 'csv-parse/sync';
 import { parse as parseYaml } from 'yaml';
 import { env } from '../config/env.js';
 
@@ -70,5 +71,98 @@ export async function fetchFecToGovtrackCrosswalk(): Promise<FecToGovtrackMap> {
   console.log(
     `🔗 Crosswalk built: ${map.size} FEC IDs across ${legislators.length} legislators`
   );
+  return map;
+}
+
+/**
+ * One GovTrack member's sponsorship-analysis scores.
+ * - ideology: 0 = most liberal/left, 1 = most conservative/right.
+ * - leadership: GovTrack's leadership score (higher = more central/influential
+ *   sponsor); unbounded-ish, not a percentage.
+ */
+export interface GovtrackScore {
+  govtrackId: number;
+  ideology?: number;
+  leadership?: number;
+}
+
+/** Map of GovTrack person ID -> ideology/leadership scores. */
+export type GovtrackScoreMap = Map<number, GovtrackScore>;
+
+const CHAMBER_FILES: Record<'house' | 'senate', string> = {
+  house: 'sponsorshipanalysis_h.txt',
+  senate: 'sponsorshipanalysis_s.txt',
+};
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (value == null || value === '') return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Fetch and parse one GovTrack sponsorship-analysis file (House or Senate) for
+ * a given Congress. The file is CSV with a header row; we key columns by
+ * normalized (lowercased/trimmed) header name so we're resilient to column
+ * ordering: we need `id`, `ideology`, and `leadership`.
+ */
+async function fetchGovtrackChamber(
+  congress: number,
+  chamber: 'house' | 'senate'
+): Promise<GovtrackScore[]> {
+  const url = `${env.IDEOLOGY_GOVTRACK_BASE_URL}/${congress}/${CHAMBER_FILES[chamber]}`;
+  console.log(`📥 Fetching GovTrack ${chamber} ideology analysis: ${url}`);
+
+  const response = await axios.get<string>(url, {
+    timeout: 30000,
+    responseType: 'text',
+  });
+
+  const rows = parseCsv(response.data, {
+    columns: (header: string[]) => header.map((h) => h.trim().toLowerCase()),
+    skip_empty_lines: true,
+    trim: true,
+  }) as Record<string, string>[];
+
+  const scores: GovtrackScore[] = [];
+  for (const row of rows) {
+    const govtrackId = toFiniteNumber(row.id);
+    if (govtrackId == null) continue;
+    scores.push({
+      govtrackId,
+      ideology: toFiniteNumber(row.ideology),
+      leadership: toFiniteNumber(row.leadership),
+    });
+  }
+
+  if (scores.length === 0) {
+    throw new Error(
+      `GovTrack ${chamber} analysis for Congress ${congress} parsed 0 rows — ` +
+        `the file format may have changed (expected CSV with id/ideology/leadership columns).`
+    );
+  }
+
+  console.log(`📊 GovTrack ${chamber}: parsed ${scores.length} member scores`);
+  return scores;
+}
+
+/**
+ * Fetch both chambers' GovTrack sponsorship-analysis for a Congress and return
+ * a single Map keyed by GovTrack person ID.
+ */
+export async function fetchGovtrackAnalysis(
+  congress: number
+): Promise<GovtrackScoreMap> {
+  const [house, senate] = await Promise.all([
+    fetchGovtrackChamber(congress, 'house'),
+    fetchGovtrackChamber(congress, 'senate'),
+  ]);
+
+  const map: GovtrackScoreMap = new Map();
+  for (const score of [...house, ...senate]) {
+    map.set(score.govtrackId, score);
+  }
+
+  console.log(`📊 GovTrack analysis: ${map.size} members for Congress ${congress}`);
   return map;
 }

--- a/backend/src/services/ideology.service.ts
+++ b/backend/src/services/ideology.service.ts
@@ -1,0 +1,74 @@
+/**
+ * Ideology scoring service (issue #33) — GovTrack-based methodology.
+ *
+ * Populates the `IdeologyScore` table for incumbent candidates using the
+ * ideology + leadership scores GovTrack derives from congressional
+ * cosponsorship networks. This is the data layer behind the "Ideology Score"
+ * spectrum and (future) voting-record scorecard on candidate profiles.
+ *
+ * Pipeline:
+ *   1. Fetch the unitedstates/congress-legislators crosswalk to map our
+ *      FEC candidate IDs -> GovTrack person IDs. (Our candidates are keyed by
+ *      FEC ID; GovTrack's analysis is keyed by GovTrack person ID.)
+ *   2. Fetch GovTrack's per-Congress sponsorship-analysis files (House + Senate)
+ *      which contain ideology + leadership scores per GovTrack person ID.
+ *   3. Join the two and upsert one IdeologyScore row per matched candidate.
+ *
+ * Network note: GovTrack (www.govtrack.us) and the raw congress-legislators
+ * host must be reachable from wherever this runs. Both are configurable via
+ * env (IDEOLOGY_GOVTRACK_BASE_URL, IDEOLOGY_LEGISLATORS_URL).
+ */
+
+import axios from 'axios';
+import { parse as parseYaml } from 'yaml';
+import { env } from '../config/env.js';
+
+/**
+ * Map of FEC candidate ID -> GovTrack person ID, built from the
+ * congress-legislators crosswalk. A single legislator can have several FEC IDs
+ * (e.g. a House member who later ran for Senate), so we index every FEC ID.
+ */
+export type FecToGovtrackMap = Map<string, number>;
+
+/** Shape of a single legislator entry in legislators-current.yaml (subset). */
+interface LegislatorEntry {
+  id?: {
+    govtrack?: number;
+    fec?: string[];
+    bioguide?: string;
+  };
+}
+
+/**
+ * Fetch and parse the congress-legislators crosswalk, returning a lookup from
+ * FEC candidate ID to GovTrack person ID.
+ */
+export async function fetchFecToGovtrackCrosswalk(): Promise<FecToGovtrackMap> {
+  const url = env.IDEOLOGY_LEGISLATORS_URL;
+  console.log(`🔗 Fetching FEC↔GovTrack crosswalk: ${url}`);
+
+  const response = await axios.get<string>(url, {
+    timeout: 30000,
+    responseType: 'text',
+  });
+
+  const legislators = parseYaml(response.data) as LegislatorEntry[];
+  if (!Array.isArray(legislators)) {
+    throw new Error('Unexpected congress-legislators format: expected a list');
+  }
+
+  const map: FecToGovtrackMap = new Map();
+  for (const leg of legislators) {
+    const govtrackId = leg.id?.govtrack;
+    const fecIds = leg.id?.fec;
+    if (govtrackId == null || !Array.isArray(fecIds)) continue;
+    for (const fecId of fecIds) {
+      if (fecId) map.set(fecId, govtrackId);
+    }
+  }
+
+  console.log(
+    `🔗 Crosswalk built: ${map.size} FEC IDs across ${legislators.length} legislators`
+  );
+  return map;
+}

--- a/backend/src/services/lobby.service.ts
+++ b/backend/src/services/lobby.service.ts
@@ -1,0 +1,260 @@
+import { prisma } from '../config/database.js';
+import { LOBBIES, LobbyDefinition } from '../data/lobbies.js';
+
+export interface LobbyContributor {
+  name: string;
+  employer: string | null;
+  amount: number;
+  count: number;
+}
+
+export interface LobbyBucket {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  totalAmount: number;
+  contributionCount: number;
+  percentageOfReceipts: number;
+  topContributors: LobbyContributor[];
+}
+
+export interface LobbyBreakdownResult {
+  candidateId: string;
+  candidateName: string;
+  cycle: number;
+  totalReceipts: number;
+  totalLobbyAmount: number;
+  classifiedPercentage: number;
+  lobbies: LobbyBucket[];
+  lastComputed: string;
+  notes: string[];
+}
+
+/**
+ * Strip regex-only tokens so a pattern can be used as a SQL ILIKE substring.
+ * (Word boundaries / character classes are dropped — final classification
+ * still uses real regex on the in-memory result, this is just a coarse
+ * pre-filter to limit how many rows we pull from the DB.)
+ */
+function patternToSqlSubstring(pattern: string): string {
+  return pattern
+    .replace(/\\b/g, '')
+    .replace(/\.\*/g, ' ')
+    .replace(/\\\./g, '.')
+    .replace(/[\^$()|+?{}[\]]/g, '')
+    .trim();
+}
+
+function compilePattern(pattern: string): RegExp {
+  return new RegExp(pattern, 'i');
+}
+
+interface CompiledLobby extends LobbyDefinition {
+  nameRegexes: RegExp[];
+  employerRegexes: RegExp[];
+  committeeIdSet: Set<string>;
+}
+
+const COMPILED: CompiledLobby[] = LOBBIES.map((l) => ({
+  ...l,
+  nameRegexes: l.namePatterns.map(compilePattern),
+  employerRegexes: l.employerPatterns.map(compilePattern),
+  committeeIdSet: new Set(l.committeeIds),
+}));
+
+function matchLobby(
+  contributorName: string | null,
+  contributorEmployer: string | null,
+): CompiledLobby | null {
+  for (const lobby of COMPILED) {
+    if (contributorName) {
+      for (const re of lobby.nameRegexes) {
+        if (re.test(contributorName)) return lobby;
+      }
+    }
+    if (contributorEmployer) {
+      for (const re of lobby.employerRegexes) {
+        if (re.test(contributorEmployer)) return lobby;
+      }
+    }
+  }
+  return null;
+}
+
+export class LobbyService {
+  /**
+   * Get the static catalog of supported lobbies (for UI legends, filters).
+   */
+  getLobbyCatalog(): { id: string; name: string; description: string; color: string }[] {
+    return LOBBIES.map((l) => ({
+      id: l.id,
+      name: l.name,
+      description: l.description,
+      color: l.color,
+    }));
+  }
+
+  /**
+   * Aggregate a candidate's receipts into lobby buckets.
+   *
+   * Strategy:
+   *   1. Find the candidate's committees.
+   *   2. Pre-filter receipts in SQL via a giant OR of ILIKE substrings
+   *      (so we don't scan tens of thousands of rows in JS).
+   *   3. Classify each candidate receipt in JS using the compiled regexes,
+   *      bucket by lobby, and track top contributors.
+   *   4. Compute percentage of *total* receipts for context.
+   */
+  async getLobbyBreakdown(
+    candidateDbId: string,
+    cycle: number = 2026,
+  ): Promise<LobbyBreakdownResult> {
+    const candidate = await prisma.candidate.findUnique({
+      where: { id: candidateDbId },
+      include: { committees: true },
+    });
+
+    if (!candidate) {
+      throw new Error('Candidate not found');
+    }
+
+    const committeeIds = candidate.committees.map((c) => c.committeeId);
+    const buckets = new Map<string, LobbyBucket>();
+    const contributorByLobby = new Map<string, Map<string, LobbyContributor>>();
+
+    for (const lobby of COMPILED) {
+      buckets.set(lobby.id, {
+        id: lobby.id,
+        name: lobby.name,
+        description: lobby.description,
+        color: lobby.color,
+        totalAmount: 0,
+        contributionCount: 0,
+        percentageOfReceipts: 0,
+        topContributors: [],
+      });
+      contributorByLobby.set(lobby.id, new Map());
+    }
+
+    if (committeeIds.length === 0) {
+      return {
+        candidateId: candidate.candidateId,
+        candidateName: candidate.name,
+        cycle,
+        totalReceipts: 0,
+        totalLobbyAmount: 0,
+        classifiedPercentage: 0,
+        lobbies: Array.from(buckets.values()),
+        lastComputed: new Date().toISOString(),
+        notes: ['No committees on file for this candidate.'],
+      };
+    }
+
+    // Build the OR pre-filter from every name/employer pattern across all lobbies.
+    const orFilters: object[] = [];
+    for (const lobby of LOBBIES) {
+      for (const pattern of lobby.namePatterns) {
+        const term = patternToSqlSubstring(pattern);
+        if (term.length >= 2) {
+          orFilters.push({ contributorName: { contains: term, mode: 'insensitive' } });
+        }
+      }
+      for (const pattern of lobby.employerPatterns) {
+        const term = patternToSqlSubstring(pattern);
+        if (term.length >= 2) {
+          orFilters.push({ contributorEmployer: { contains: term, mode: 'insensitive' } });
+        }
+      }
+    }
+
+    // Cycle window: a 2-year cycle covers donations from Jan of the prior odd
+    // year through Dec of the cycle year (e.g. cycle=2026 → 2025-01-01..2026-12-31).
+    const cycleStart = new Date(`${cycle - 1}-01-01T00:00:00Z`);
+    const cycleEnd = new Date(`${cycle}-12-31T23:59:59Z`);
+
+    const [candidateReceipts, totalAgg] = await Promise.all([
+      prisma.receipt.findMany({
+        where: {
+          committeeId: { in: committeeIds },
+          contributionReceiptDate: { gte: cycleStart, lte: cycleEnd },
+          OR: orFilters,
+        },
+        select: {
+          contributorName: true,
+          contributorEmployer: true,
+          contributionReceiptAmount: true,
+        },
+      }),
+      prisma.receipt.aggregate({
+        where: {
+          committeeId: { in: committeeIds },
+          contributionReceiptDate: { gte: cycleStart, lte: cycleEnd },
+        },
+        _sum: { contributionReceiptAmount: true },
+      }),
+    ]);
+
+    let totalLobbyAmount = 0;
+
+    for (const r of candidateReceipts) {
+      const lobby = matchLobby(r.contributorName, r.contributorEmployer);
+      if (!lobby) continue;
+
+      const amount = r.contributionReceiptAmount?.toNumber() ?? 0;
+      if (amount <= 0) continue;
+
+      const bucket = buckets.get(lobby.id)!;
+      bucket.totalAmount += amount;
+      bucket.contributionCount += 1;
+      totalLobbyAmount += amount;
+
+      const key = (r.contributorName ?? 'Unknown').trim().toUpperCase();
+      const contribMap = contributorByLobby.get(lobby.id)!;
+      const existing = contribMap.get(key);
+      if (existing) {
+        existing.amount += amount;
+        existing.count += 1;
+      } else {
+        contribMap.set(key, {
+          name: r.contributorName ?? 'Unknown',
+          employer: r.contributorEmployer,
+          amount,
+          count: 1,
+        });
+      }
+    }
+
+    const totalReceipts = totalAgg._sum.contributionReceiptAmount?.toNumber() ?? 0;
+
+    for (const bucket of buckets.values()) {
+      const top = Array.from(contributorByLobby.get(bucket.id)!.values())
+        .sort((a, b) => b.amount - a.amount)
+        .slice(0, 5);
+      bucket.topContributors = top;
+      bucket.percentageOfReceipts =
+        totalReceipts > 0 ? Math.round((bucket.totalAmount / totalReceipts) * 1000) / 10 : 0;
+    }
+
+    const lobbies = Array.from(buckets.values()).sort((a, b) => b.totalAmount - a.totalAmount);
+
+    return {
+      candidateId: candidate.candidateId,
+      candidateName: candidate.name,
+      cycle,
+      totalReceipts,
+      totalLobbyAmount,
+      classifiedPercentage:
+        totalReceipts > 0 ? Math.round((totalLobbyAmount / totalReceipts) * 1000) / 10 : 0,
+      lobbies,
+      lastComputed: new Date().toISOString(),
+      notes: [
+        'Classification uses keyword matching against contributor name and employer fields from FEC Schedule A filings.',
+        'Itemized individual contributions only exist for donations over $200; smaller donations are not classified here.',
+        'Self-reported employer fields ("Self", "Retired", etc.) cause undercounting — totals are a lower bound.',
+      ],
+    };
+  }
+}
+
+export const lobbyService = new LobbyService();

--- a/backend/src/services/lobby.service.ts
+++ b/backend/src/services/lobby.service.ts
@@ -46,6 +46,10 @@ function patternToSqlSubstring(pattern: string): string {
     .trim();
 }
 
+// Compiles a single pattern from LOBBIES into a RegExp. Only ever called
+// at module load over the static, developer-controlled LOBBIES constant
+// (see COMPILED below) — never reachable from request input, so no ReDoS
+// surface despite accepting `string`.
 function compilePattern(pattern: string): RegExp {
   return new RegExp(pattern, 'i');
 }


### PR DESCRIPTION
Voters can now click into any candidate and see how much money they have
accepted from major industry lobbies, in addition to the existing
top-donor list.

Backend:
- src/data/lobbies.ts: hand-curated taxonomy (committee IDs, contributor
  name patterns, employer patterns) for 7 lobby buckets.
- src/services/lobby.service.ts: aggregates Receipt rows for a candidate
  into lobby buckets, with cycle-windowed totals, top contributors per
  lobby, and percentage-of-receipts context.
- GET /api/candidates/:id/lobby-breakdown and GET /api/lobbies endpoints.

Frontend:
- LobbyBreakdown component with sorted bars, expandable top contributors
  per lobby, and inline disclaimers about FEC itemization limits.
- Wired into the existing Campaign Finance tab on the candidate profile.

PHASE5_PLAN.md documents the design, tradeoffs, and future extensions
(precomputed aggregates, OpenSecrets CRP integration, candidate-list
filtering).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Industry & Lobby Breakdown section to candidate profiles, displaying donation amounts from major lobbies including AI/Big Tech, Oil & Gas, Pro-Israel, Pharma, Defense, Crypto, and Labor.
  * Expanded lobby sections show top contributors and contribution counts with visual progress indicators.
  * Enhanced candidate ideology scoring display with rounded values and improved methodology documentation.

* **Documentation**
  * Added ideology scoring sync process documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->